### PR TITLE
- Fix: Sputnik suppresses error from PMD when the rules in configuration...

### DIFF
--- a/src/main/java/pl/touk/sputnik/connector/gerrit/GerritFacade.java
+++ b/src/main/java/pl/touk/sputnik/connector/gerrit/GerritFacade.java
@@ -47,7 +47,7 @@ public class GerritFacade implements ConnectorFacade {
             }
             return files;
         } catch (IOException | URISyntaxException e) {
-            throw new GerritException("Error listing files", e);
+            throw new GerritException("Error when listing files", e);
         }
     }
 
@@ -57,7 +57,7 @@ public class GerritFacade implements ConnectorFacade {
             String json = objectMapper.writeValueAsString(new ReviewInputBuilder().toReviewInput(review));
             gerritConnector.sendReview(json);
         } catch (IOException | URISyntaxException e) {
-            throw new GerritException("Error setting review", e);
+            throw new GerritException("Error when setting review", e);
         }
     }
 

--- a/src/main/java/pl/touk/sputnik/connector/stash/StashFacade.java
+++ b/src/main/java/pl/touk/sputnik/connector/stash/StashFacade.java
@@ -49,7 +49,7 @@ public class StashFacade implements ConnectorFacade {
             }
             return files;
         } catch (URISyntaxException | IOException e) {
-            throw new StashException("Error listing files", e);
+            throw new StashException("Error when listing files", e);
         }
     }
 

--- a/src/test/java/pl/touk/sputnik/connector/gerrit/GerritFacadeExceptionTest.java
+++ b/src/test/java/pl/touk/sputnik/connector/gerrit/GerritFacadeExceptionTest.java
@@ -33,7 +33,7 @@ public class GerritFacadeExceptionTest {
         //then
         assertThat(caughtException())
                 .isInstanceOf(GerritException.class)
-                .hasMessageContaining("Error listing files");
+                .hasMessageContaining("Error when listing files");
     }
 
 }


### PR DESCRIPTION
- Fix: Sputnik suppresses error from PMD when the rules in configuration were not present in jar
- Change one error to more descriptive for user
