### PR TITLE
Warn when user wants to configure properties in way it is not fully supported

### DIFF
--- a/src/main/java/pl/touk/sputnik/Main.java
+++ b/src/main/java/pl/touk/sputnik/Main.java
@@ -4,12 +4,16 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.ParseException;
 import org.jetbrains.annotations.NotNull;
+
 import pl.touk.sputnik.configuration.CliOption;
 import pl.touk.sputnik.configuration.CliWrapper;
+import pl.touk.sputnik.configuration.Configuration;
 import pl.touk.sputnik.configuration.ConfigurationHolder;
 import pl.touk.sputnik.configuration.GeneralOption;
+import pl.touk.sputnik.configuration.GeneralOptionNotSupportedException;
 import pl.touk.sputnik.connector.ConnectorFacade;
 import pl.touk.sputnik.connector.ConnectorFacadeFactory;
+import pl.touk.sputnik.connector.ConnectorType;
 import pl.touk.sputnik.engine.Engine;
 
 public final class Main {
@@ -31,10 +35,25 @@ public final class Main {
         }
 
         ConfigurationHolder.initFromFile(commandLine.getOptionValue(CliOption.CONF.getCommandLineParam()));
-        ConfigurationHolder.instance().updateWithCliOptions(commandLine);
-        ConnectorFacade facade = ConnectorFacadeFactory.INSTANCE.build(ConfigurationHolder.instance().getProperty(GeneralOption.CONNECTOR_TYPE));
+        Configuration configuration = ConfigurationHolder.instance();
+        configuration.updateWithCliOptions(commandLine);
 
+        ConnectorFacade facade = getConnectorFacade(configuration);
         new Engine(facade).run();
+    }
+
+    private static ConnectorFacade getConnectorFacade(Configuration configuration) {
+        ConnectorType connectorType = ConnectorType.getValidConnectorType(configuration
+                .getProperty(GeneralOption.CONNECTOR_TYPE));
+        ConnectorFacade facade = null;
+        try {
+            facade = ConnectorFacadeFactory.INSTANCE.build(connectorType);
+            facade.validate(ConfigurationHolder.instance());
+        } catch (GeneralOptionNotSupportedException e) {
+            System.out.println(e.getMessage());
+            System.exit(2);
+        }
+        return facade;
     }
 
     private static void printUsage(@NotNull CliWrapper cliOptions) {

--- a/src/main/java/pl/touk/sputnik/configuration/GeneralOptionNotSupportedException.java
+++ b/src/main/java/pl/touk/sputnik/configuration/GeneralOptionNotSupportedException.java
@@ -1,0 +1,17 @@
+package pl.touk.sputnik.configuration;
+
+import pl.touk.sputnik.connector.Connector;
+
+/**
+ * Used to inform that given {@link GeneralOption} is not supported by selected {#link {@link Connector}.
+ */
+public class GeneralOptionNotSupportedException extends RuntimeException {
+
+    public GeneralOptionNotSupportedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public GeneralOptionNotSupportedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/pl/touk/sputnik/connector/ConnectorFacade.java
+++ b/src/main/java/pl/touk/sputnik/connector/ConnectorFacade.java
@@ -1,6 +1,9 @@
 package pl.touk.sputnik.connector;
 
 import org.jetbrains.annotations.NotNull;
+
+import pl.touk.sputnik.configuration.Configuration;
+import pl.touk.sputnik.configuration.GeneralOptionNotSupportedException;
 import pl.touk.sputnik.review.Review;
 import pl.touk.sputnik.review.ReviewFile;
 
@@ -11,6 +14,14 @@ public interface ConnectorFacade {
 
     @NotNull
     List<ReviewFile> listFiles();
+
+    /**
+     * Validates if given options are supported by selected connector.
+     * 
+     * @throws GeneralOptionNotSupportedException
+     *             if passed configuration is not valid or not fully supported
+     */
+    void validate(Configuration configuration) throws GeneralOptionNotSupportedException;
 
     void setReview(@NotNull Review review);
 }

--- a/src/main/java/pl/touk/sputnik/connector/ConnectorFacadeFactory.java
+++ b/src/main/java/pl/touk/sputnik/connector/ConnectorFacadeFactory.java
@@ -1,27 +1,26 @@
 package pl.touk.sputnik.connector;
 
 import org.jetbrains.annotations.NotNull;
+
+import pl.touk.sputnik.configuration.GeneralOptionNotSupportedException;
 import pl.touk.sputnik.connector.gerrit.GerritFacadeBuilder;
 import pl.touk.sputnik.connector.stash.StashFacadeBuilder;
 
 public class ConnectorFacadeFactory {
     public static final ConnectorFacadeFactory INSTANCE = new ConnectorFacadeFactory();
 
-    private static final String GERRIT = "gerrit";
-    private static final String STASH = "stash";
-
     GerritFacadeBuilder gerritFacadeBuilder = new GerritFacadeBuilder();
     StashFacadeBuilder stashFacadeBuilder = new StashFacadeBuilder();
 
     @NotNull
-    public ConnectorFacade build(String key) {
-        switch (key) {
+    public ConnectorFacade build(@NotNull ConnectorType type) {
+        switch (type) {
             case STASH:
                 return stashFacadeBuilder.build();
             case GERRIT:
                 return gerritFacadeBuilder.build();
             default:
-                throw new IllegalArgumentException("Connector " + key + " is not supported");
+                throw new GeneralOptionNotSupportedException("Connector " + type.getName() + " is not supported");
         }
     }
 }

--- a/src/main/java/pl/touk/sputnik/connector/ConnectorType.java
+++ b/src/main/java/pl/touk/sputnik/connector/ConnectorType.java
@@ -1,0 +1,36 @@
+package pl.touk.sputnik.connector;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Supported connectors.
+ */
+@Slf4j
+public enum ConnectorType {
+    GERRIT("gerrit"),
+    STASH("stash");
+
+    /** Name used in configuration file. */
+    @Getter
+    private final String name;
+
+    ConnectorType(String name) {
+        this.name = name;
+    }
+
+    @NotNull
+    public static ConnectorType getValidConnectorType(@Nullable String connectorName) {
+        for (ConnectorType connectorType : values()) {
+            if (connectorType.getName().equals(connectorName)) {
+                return connectorType;
+            }
+        }
+
+        log.error(String.format("Given connector (%s) is not valid, returned default one!", connectorName));
+        return GERRIT;
+    }
+}

--- a/src/main/java/pl/touk/sputnik/connector/gerrit/GerritFacade.java
+++ b/src/main/java/pl/touk/sputnik/connector/gerrit/GerritFacade.java
@@ -1,10 +1,17 @@
 package pl.touk.sputnik.connector.gerrit;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
+
+import pl.touk.sputnik.configuration.Configuration;
+import pl.touk.sputnik.configuration.GeneralOption;
+import pl.touk.sputnik.configuration.GeneralOptionNotSupportedException;
 import pl.touk.sputnik.connector.ConnectorFacade;
-import pl.touk.sputnik.connector.gerrit.json.*;
+import pl.touk.sputnik.connector.Connectors;
+import pl.touk.sputnik.connector.gerrit.json.FileInfo;
+import pl.touk.sputnik.connector.gerrit.json.ListFilesResponse;
 import pl.touk.sputnik.review.Review;
 import pl.touk.sputnik.review.ReviewFile;
 
@@ -14,7 +21,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import pl.touk.sputnik.connector.Connectors;
 
 public class GerritFacade implements ConnectorFacade {
     private static final String RESPONSE_PREFIX = ")]}'";
@@ -62,7 +68,6 @@ public class GerritFacade implements ConnectorFacade {
     }
 
 
-
     @NotNull
     protected String trimResponse(@NotNull String response) {
         return StringUtils.replaceOnce(response, RESPONSE_PREFIX, "");
@@ -71,5 +76,16 @@ public class GerritFacade implements ConnectorFacade {
     @Override
     public Connectors name() {
         return Connectors.GERRIT;
+    }
+
+    @Override
+    public void validate(Configuration configuration) throws GeneralOptionNotSupportedException {
+        boolean commentOnlyChangedLines = Boolean.parseBoolean(configuration
+                .getProperty(GeneralOption.COMMENT_ONLY_CHANGED_LINES));
+
+        if (commentOnlyChangedLines) {
+            throw new GeneralOptionNotSupportedException("This connector does not support "
+                    + GeneralOption.COMMENT_ONLY_CHANGED_LINES.getKey());
+        }
     }
 }

--- a/src/main/java/pl/touk/sputnik/connector/stash/StashFacade.java
+++ b/src/main/java/pl/touk/sputnik/connector/stash/StashFacade.java
@@ -6,9 +6,12 @@ import com.google.common.collect.Lists;
 import com.jayway.jsonpath.JsonPath;
 import lombok.extern.slf4j.Slf4j;
 import net.minidev.json.JSONObject;
+
 import org.jetbrains.annotations.NotNull;
+import pl.touk.sputnik.configuration.Configuration;
 import pl.touk.sputnik.configuration.ConfigurationHolder;
 import pl.touk.sputnik.configuration.GeneralOption;
+import pl.touk.sputnik.configuration.GeneralOptionNotSupportedException;
 import pl.touk.sputnik.connector.ConnectorFacade;
 import pl.touk.sputnik.connector.Connectors;
 import pl.touk.sputnik.connector.stash.json.*;
@@ -145,5 +148,10 @@ public class StashFacade implements ConnectorFacade {
         } catch (URISyntaxException | IOException e) {
             throw new StashException("Error parsing json strings to objects", e);
         }
+    }
+
+    @Override
+    public void validate(Configuration configuration) throws GeneralOptionNotSupportedException {
+        // all features are suppored by Stash
     }
 }

--- a/src/test/java/pl/touk/sputnik/connector/ConnectorFacadeFactoryTest.java
+++ b/src/test/java/pl/touk/sputnik/connector/ConnectorFacadeFactoryTest.java
@@ -2,11 +2,10 @@ package pl.touk.sputnik.connector;
 
 import org.junit.Before;
 import org.junit.Test;
+
 import pl.touk.sputnik.connector.gerrit.GerritFacade;
 import pl.touk.sputnik.connector.gerrit.GerritFacadeBuilder;
 
-import static com.googlecode.catchexception.CatchException.catchException;
-import static com.googlecode.catchexception.CatchException.caughtException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -22,21 +21,16 @@ public class ConnectorFacadeFactoryTest {
 
     @Test
     public void shouldBuildConnector() {
+        // given
         GerritFacadeBuilder gerritFacadeBuilderMock = mock(GerritFacadeBuilder.class);
         GerritFacade gerritFacadeMock = mock(GerritFacade.class);
         when(gerritFacadeBuilderMock.build()).thenReturn(gerritFacadeMock);
         connectorFacadeFactory.gerritFacadeBuilder = gerritFacadeBuilderMock;
-        ConnectorFacade facade = connectorFacadeFactory.build("gerrit");
 
+        // when
+        ConnectorFacade facade = connectorFacadeFactory.build(ConnectorType.GERRIT);
+
+        // then
         assertThat(facade).isEqualTo(gerritFacadeMock);
     }
-
-    @Test
-    public void shouldThrowIfKeyIsUnknown() {
-        catchException(connectorFacadeFactory).build("unknown");
-
-        assertThat(caughtException()).isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Connector unknown is not supported");
-    }
-
 }

--- a/src/test/java/pl/touk/sputnik/connector/FacadeConfigUtil.java
+++ b/src/test/java/pl/touk/sputnik/connector/FacadeConfigUtil.java
@@ -1,6 +1,5 @@
 package pl.touk.sputnik.connector;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/src/test/java/pl/touk/sputnik/connector/gerrit/GerritFacadeHttpsTest.java
+++ b/src/test/java/pl/touk/sputnik/connector/gerrit/GerritFacadeHttpsTest.java
@@ -8,7 +8,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import pl.touk.sputnik.configuration.ConfigurationSetup;
 import pl.touk.sputnik.connector.FacadeConfigUtil;
-import pl.touk.sputnik.connector.stash.StashFacadeBuilder;
 import pl.touk.sputnik.review.ReviewFile;
 
 import java.util.List;

--- a/src/test/java/pl/touk/sputnik/connector/gerrit/GerritFacadeTest.java
+++ b/src/test/java/pl/touk/sputnik/connector/gerrit/GerritFacadeTest.java
@@ -2,11 +2,22 @@ package pl.touk.sputnik.connector.gerrit;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
+import com.google.common.collect.ImmutableMap;
+
+import static com.googlecode.catchexception.CatchException.catchException;
+import static com.googlecode.catchexception.CatchException.caughtException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+
+import pl.touk.sputnik.configuration.ConfigurationHolder;
+import pl.touk.sputnik.configuration.ConfigurationSetup;
+import pl.touk.sputnik.configuration.GeneralOptionNotSupportedException;
+import pl.touk.sputnik.connector.ConnectorFacade;
+import pl.touk.sputnik.connector.ConnectorFacadeFactory;
+import pl.touk.sputnik.connector.ConnectorType;
 import pl.touk.sputnik.review.ReviewFile;
 
 import java.io.IOException;
@@ -24,6 +35,25 @@ public class GerritFacadeTest {
 
     @InjectMocks
     private GerritFacade gerritFacade;
+
+    @Test
+    public void shouldNotAllowCommentOnlyChangedLines() {
+        // given
+        new ConfigurationSetup().setUp(ImmutableMap.of(
+                "cli.changeId", "abc",
+                "cli.revisionId", "def",
+                "global.commentOnlyChangedLines", Boolean.toString(true)));
+
+        ConnectorFacadeFactory connectionFacade = new ConnectorFacadeFactory();
+        
+        // when
+        ConnectorFacade gerritFacade = connectionFacade.build(ConnectorType.GERRIT);
+        catchException(gerritFacade).validate(ConfigurationHolder.instance());
+
+        // then
+        assertThat(caughtException()).isInstanceOf(GeneralOptionNotSupportedException.class).hasMessage(
+                "This connector does not support global.commentOnlyChangedLines");
+    }
 
     @Test
     public void shouldParseListFilesResponse() throws IOException, URISyntaxException {

--- a/src/test/java/pl/touk/sputnik/connector/stash/StashFacadeHttpsTest.java
+++ b/src/test/java/pl/touk/sputnik/connector/stash/StashFacadeHttpsTest.java
@@ -10,9 +10,7 @@ import pl.touk.sputnik.configuration.ConfigurationSetup;
 import pl.touk.sputnik.connector.FacadeConfigUtil;
 import pl.touk.sputnik.review.ReviewFile;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/pl/touk/sputnik/connector/stash/StashFacadeTest.java
+++ b/src/test/java/pl/touk/sputnik/connector/stash/StashFacadeTest.java
@@ -30,7 +30,7 @@ public class StashFacadeTest {
             "connector.projectKey", SOME_PROJECT_KEY
     );
 
-    private StashFacade fixture;
+    private StashFacade stashFacade;
 
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(FacadeConfigUtil.HTTP_PORT);
@@ -38,7 +38,7 @@ public class StashFacadeTest {
     @Before
     public void setUp() {
         new ConfigurationSetup().setUp(FacadeConfigUtil.getHttpConfig("stash"), STASH_PATCHSET_MAP);
-        fixture = new StashFacadeBuilder().build();
+        stashFacade = new StashFacadeBuilder().build();
     }
 
     @Test
@@ -47,7 +47,7 @@ public class StashFacadeTest {
                 "%s/rest/api/1.0/projects/%s/repos/%s/pull-requests/%s/changes",
                 FacadeConfigUtil.PATH, SOME_PROJECT_KEY, SOME_REPOSITORY, SOME_PULL_REQUEST_ID)), "/json/stash-changes.json");
 
-        List<ReviewFile> files = fixture.listFiles();
+        List<ReviewFile> files = stashFacade.listFiles();
         assertThat(files).hasSize(4);
     }
 
@@ -57,7 +57,7 @@ public class StashFacadeTest {
                 "%s/rest/api/1.0/projects/%s/repos/%s/pull-requests/%s/diff.*",
                 FacadeConfigUtil.PATH, SOME_PROJECT_KEY, SOME_REPOSITORY, SOME_PULL_REQUEST_ID)), "/json/stash-diff.json");
 
-        SingleFileChanges singleFileChanges = fixture.changesForSingleFile("src/main/java/Main.java");
+        SingleFileChanges singleFileChanges = stashFacade.changesForSingleFile("src/main/java/Main.java");
         assertThat(singleFileChanges.getFilename()).isEqualTo("src/main/java/Main.java");
         assertThat(singleFileChanges.getChangesMap())
                 .containsEntry(1, ChangeType.ADDED)
@@ -80,13 +80,13 @@ public class StashFacadeTest {
         review.addError("scalastyle", new Violation(filename, 1, "error message", Severity.ERROR));
         review.getMessages().add("Total 1 violations found");
 
-        fixture.setReview(review);
+        stashFacade.setReview(review);
 
         stubGet(urlMatching(String.format(
                 "%s/rest/api/1.0/projects/%s/repos/%s/pull-requests/%s/diff.*",
                 FacadeConfigUtil.PATH, SOME_PROJECT_KEY, SOME_REPOSITORY, SOME_PULL_REQUEST_ID)), "/json/stash-diff.json");
 
-        fixture.setReview(review);
+        stashFacade.setReview(review);
 
         // First review : 1 comment on file and 1 comment on summary message
         // Second review: 1 comment on summary message


### PR DESCRIPTION
- added tests for new option
- changed ConfigurationSetup.setUp to static to avoid creating instance that is not used
- changed connector types to enum