### PR TITLE
update gerrit-rest-java-client to v0.8.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ dependencies {
 
     compile 'com.jayway.jsonpath:json-path:0.9.1'
 
-    compile 'com.urswolfer.gerrit.client.rest:gerrit-rest-java-client:0.8.0'
+    compile 'com.urswolfer.gerrit.client.rest:gerrit-rest-java-client:0.8.1'
 
     // Checkstyle dependencies
     compile 'com.puppycrawl.tools:checkstyle:6.1'


### PR DESCRIPTION
- this update contains support for LDAP and HTTP digest auth