### PR TITLE
Added support for configuring JSLint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,8 @@ run {
 }
 
 repositories {
-    mavenCentral()
+        mavenCentral()
+        maven { url "http://central.maven.org/maven2" }
 }
 
 //noinspection GroovyAssignabilityCheck

--- a/src/main/java/pl/touk/sputnik/configuration/GeneralOption.java
+++ b/src/main/java/pl/touk/sputnik/configuration/GeneralOption.java
@@ -45,10 +45,10 @@ public enum GeneralOption implements ConfigurationOption {
     CODE_NARC_EXCLUDES("codenarc.excludes", "CodeNarc exclude filter", ""),
 
     JSLINT_ENABLED("jslint.enabled", "JSLint enabled", "false"),
-    JSLINT_CONFIGURATION_FILE("jslint.configurationFile", "JSLint configuration file", "jslint.properties"),
+    JSLINT_CONFIGURATION_FILE("jslint.configurationFile", "JSLint configuration file", ""),
 
     JSHINT_ENABLED("jshint.enabled", "JSHint enabled", "false"),
-    JSHINT_CONFIGURATION_FILE("jshint.configurationFile", "JSHint configuration file", "jshint.js"),
+    JSHINT_CONFIGURATION_FILE("jshint.configurationFile", "JSHint configuration file", ""),
 
     SONAR_ENABLED("sonar.enabled", "Sonar enabled", "false"),
     SONAR_PROPERTIES("sonar.configurationFiles", "Sonar base configuration", "sonar-project.properties"),

--- a/src/main/java/pl/touk/sputnik/configuration/GeneralOption.java
+++ b/src/main/java/pl/touk/sputnik/configuration/GeneralOption.java
@@ -45,10 +45,11 @@ public enum GeneralOption implements ConfigurationOption {
     CODE_NARC_EXCLUDES("codenarc.excludes", "CodeNarc exclude filter", ""),
 
     JSLINT_ENABLED("jslint.enabled", "JSLint enabled", "false"),
+    JSLINT_CONFIGURATION_FILE("jslint.configurationFile", "JSLint configuration file", "jslint.properties"),
 
     JSHINT_ENABLED("jshint.enabled", "JSHint enabled", "false"),
-    JSHINT_CONFIGURATION_FILE("jshint.configurationFile", "JSHint configuration file", ""),
- 
+    JSHINT_CONFIGURATION_FILE("jshint.configurationFile", "JSHint configuration file", "jshint.js"),
+
     SONAR_ENABLED("sonar.enabled", "Sonar enabled", "false"),
     SONAR_PROPERTIES("sonar.configurationFiles", "Sonar base configuration", "sonar-project.properties"),
     SONAR_VERBOSE("sonar.verbose", "Run sonar in verbose mode", "false");

--- a/src/main/java/pl/touk/sputnik/processor/jslint/JsLintProcessor.java
+++ b/src/main/java/pl/touk/sputnik/processor/jslint/JsLintProcessor.java
@@ -1,11 +1,8 @@
 package pl.touk.sputnik.processor.jslint;
 
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
+import lombok.extern.slf4j.Slf4j;
+import pl.touk.sputnik.configuration.ConfigurationHolder;
+import pl.touk.sputnik.configuration.GeneralOption;
 import pl.touk.sputnik.review.Review;
 import pl.touk.sputnik.review.ReviewException;
 import pl.touk.sputnik.review.ReviewProcessor;
@@ -15,20 +12,33 @@ import pl.touk.sputnik.review.Violation;
 import pl.touk.sputnik.review.filter.JavaScriptFilter;
 import pl.touk.sputnik.review.transformer.IOFileTransformer;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.commons.lang.StringUtils;
+
 import com.googlecode.jslint4java.Issue;
 import com.googlecode.jslint4java.JSLint;
 import com.googlecode.jslint4java.JSLintBuilder;
 import com.googlecode.jslint4java.JSLintResult;
+import com.googlecode.jslint4java.Option;
 
+@Slf4j
 public class JsLintProcessor implements ReviewProcessor {
 
     private static final String SOURCE_NAME = "JSLint";
 
     @Override
     public ReviewResult process(Review review) {
-        return toReviewResult(lint(review));
+        final Properties configProperties = loadBaseProperties();
+        return toReviewResult(lint(review, configProperties));
     }
-    
+
     private ReviewResult toReviewResult(List<Issue> lintIssues) {
         ReviewResult result = new ReviewResult();
         for (Issue issue : lintIssues) {
@@ -37,14 +47,28 @@ public class JsLintProcessor implements ReviewProcessor {
         return result;
     }
 
-    private List<Issue> lint(Review review) {
+    private List<Issue> lint(Review review, Properties configProperties) {
         JSLint jsLint = new JSLintBuilder().fromDefault();
+        applyProperties(jsLint, configProperties);
         List<Issue> lintIssues = new ArrayList<>();
         List<File> files = review.getFiles(new JavaScriptFilter(), new IOFileTransformer());
         for (File file : files) {
             lintIssues.addAll(lintFile(jsLint, file));
         }
         return lintIssues;
+    }
+
+    private void applyProperties(JSLint jsLint, Properties configProperties) {
+        for (String propertyName : configProperties.stringPropertyNames()) {
+            Option option;
+            try {
+                option = Option.valueOf(propertyName.toUpperCase());
+            } catch (IllegalArgumentException e) {
+                log.warn("Unknown JSLint configuration property '{}'. Continue.", propertyName);
+                continue;
+            }
+            jsLint.addOption(option, configProperties.getProperty(propertyName));
+        }
     }
 
     private List<Issue> lintFile(JSLint jsLint, File file) {
@@ -55,6 +79,27 @@ public class JsLintProcessor implements ReviewProcessor {
             throw new ReviewException("IO exception when running JSLint.", e);
         }
     }
+
+    /**
+     * Load JSHint configuration property files specified by {@link GeneralOption#JSLINT_CONFIGURATION_FILE}
+     * configuration key
+     *
+     * @return a Properties instance
+     */
+    private Properties loadBaseProperties() {
+        final Properties props = new Properties();
+        String configurationFile = ConfigurationHolder.instance().getProperty(GeneralOption.JSLINT_CONFIGURATION_FILE);
+        final File propertyFile = new File(StringUtils.strip(configurationFile));
+        log.info("Loading {}", propertyFile.getAbsolutePath());
+        try {
+            props.load(new FileInputStream(propertyFile));
+        } catch (IOException e) {
+            throw new ReviewException("IO exception when reading JSLint configuration file.", e);
+        }
+
+        return props;
+    }
+
 
     @Override
     public String getName() {

--- a/src/main/java/pl/touk/sputnik/processor/jslint/JsLintProcessor.java
+++ b/src/main/java/pl/touk/sputnik/processor/jslint/JsLintProcessor.java
@@ -13,14 +13,11 @@ import pl.touk.sputnik.review.filter.JavaScriptFilter;
 import pl.touk.sputnik.review.transformer.IOFileTransformer;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
-
-import org.apache.commons.lang.StringUtils;
 
 import com.google.common.base.Strings;
 import com.googlecode.jslint4java.Issue;
@@ -101,11 +98,11 @@ public class JsLintProcessor implements ReviewProcessor {
 
     private Properties loadProperties(String configurationFileName) {
         final Properties props = new Properties();
-        final File propertyFile = new File(StringUtils.strip(configurationFileName));
-        log.info("Loading {}", propertyFile.getAbsolutePath());
-        try {
-            props.load(new FileInputStream(propertyFile));
+        try (FileReader fileReader = new FileReader(configurationFileName)) {
+            log.info("Loading {}", configurationFileName);
+            props.load(fileReader);
         } catch (IOException e) {
+            log.error("Load JSLint properties operation failed", e);
             throw new ReviewException("IO exception when reading JSLint configuration file.", e);
         }
         return props;

--- a/src/test/java/pl/touk/sputnik/processor/jslint/JsLintProcessorTest.java
+++ b/src/test/java/pl/touk/sputnik/processor/jslint/JsLintProcessorTest.java
@@ -1,14 +1,33 @@
 package pl.touk.sputnik.processor.jslint;
 
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 import pl.touk.sputnik.TestEnvironment;
+import pl.touk.sputnik.configuration.ConfigurationHolder;
+import pl.touk.sputnik.review.Review;
+import pl.touk.sputnik.review.ReviewFile;
 import pl.touk.sputnik.review.ReviewResult;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.Resources;
 
 public class JsLintProcessorTest extends TestEnvironment {
 
     private final JsLintProcessor fixture = new JsLintProcessor();
+
+
+    @Before
+    public void setUp() throws Exception {
+        ConfigurationHolder.initFromResource("jslint/sputnik/noConfigurationFile.properties");
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        ConfigurationHolder.reset();
+    }
 
     @Test
     public void shouldReturnEmptyResultWhenNoFilesToReview() {
@@ -33,6 +52,25 @@ public class JsLintProcessorTest extends TestEnvironment {
                 .containsOnly(
                         "Use spaces, not tabs.",
                         "Missing 'use strict' statement."
+                );
+    }
+
+    @Test
+    public void shouldReturnOneViolationWithConfigurationOnSimpleFunction() {
+        // given
+        ConfigurationHolder.initFromResource("jslint/sputnik/withConfigurationFile.properties");
+        Review review = new Review(ImmutableList.of(new ReviewFile(Resources.getResource("js/test.js").getFile())));
+
+        // when
+        ReviewResult reviewResult = fixture.process(review);
+
+        // then
+        assertThat(reviewResult).isNotNull();
+        assertThat(reviewResult.getViolations()).hasSize(1);
+        assertThat(reviewResult.getViolations())
+                .extracting("message")
+                .containsOnly(
+                        "'alert' is not defined."
                 );
     }
 }

--- a/src/test/java/pl/touk/sputnik/processor/jslint/JsLintProcessorTest.java
+++ b/src/test/java/pl/touk/sputnik/processor/jslint/JsLintProcessorTest.java
@@ -1,6 +1,5 @@
 package pl.touk.sputnik.processor.jslint;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import pl.touk.sputnik.TestEnvironment;
 import pl.touk.sputnik.configuration.ConfigurationHolder;
 import pl.touk.sputnik.review.Review;
@@ -13,6 +12,8 @@ import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Resources;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class JsLintProcessorTest extends TestEnvironment {
 
@@ -31,8 +32,11 @@ public class JsLintProcessorTest extends TestEnvironment {
 
     @Test
     public void shouldReturnEmptyResultWhenNoFilesToReview() {
+        // given
+        Review review = new Review(ImmutableList.of(new ReviewFile("test")));
+
         // when
-        ReviewResult reviewResult = fixture.process(nonexistantReview());
+        ReviewResult reviewResult = fixture.process(review);
 
         // then
         assertThat(reviewResult).isNotNull();
@@ -40,17 +44,19 @@ public class JsLintProcessorTest extends TestEnvironment {
     }
 
     @Test
-    public void shouldReturnBasicViolationsOnSimpleFunction() {
+    public void shouldReturnNoViolationsOnSimpleFunction() {
+        // given
+        Review review = new Review(ImmutableList.of(new ReviewFile(Resources.getResource("js/test.js").getFile())));
+
         // when
-        ReviewResult reviewResult = fixture.process(review("js/test.js"));
+        ReviewResult reviewResult = fixture.process(review);
 
         // then
         assertThat(reviewResult).isNotNull();
-        assertThat(reviewResult.getViolations()).hasSize(2);
+        assertThat(reviewResult.getViolations()).hasSize(1);
         assertThat(reviewResult.getViolations())
                 .extracting("message")
                 .containsOnly(
-                        "Use spaces, not tabs.",
                         "Missing 'use strict' statement."
                 );
     }
@@ -70,7 +76,7 @@ public class JsLintProcessorTest extends TestEnvironment {
         assertThat(reviewResult.getViolations())
                 .extracting("message")
                 .containsOnly(
-                        "'alert' is not defined."
+                        "Missing 'use strict' statement."
                 );
     }
 }

--- a/src/test/resources/js/test.js
+++ b/src/test/resources/js/test.js
@@ -1,4 +1,3 @@
-
 function test() {
-	alert('foo bar');
+    alert('foo bar');
 }

--- a/src/test/resources/jshint/jshint.json
+++ b/src/test/resources/jshint/jshint.json
@@ -1,3 +1,3 @@
 {
-    "undef": true,
+    "undef": true
 }

--- a/src/test/resources/jslint/jslint.properties
+++ b/src/test/resources/jslint/jslint.properties
@@ -1,0 +1,6 @@
+devel = false
+browser = true
+todo = true
+plusplus = true
+regexp = true
+nomen = true

--- a/src/test/resources/jslint/sputnik/noConfigurationFile.properties
+++ b/src/test/resources/jslint/sputnik/noConfigurationFile.properties
@@ -1,0 +1,1 @@
+jslint.enabled=true

--- a/src/test/resources/jslint/sputnik/withConfigurationFile.properties
+++ b/src/test/resources/jslint/sputnik/withConfigurationFile.properties
@@ -1,0 +1,2 @@
+jslint.enabled=true
+jslint.configurationFile=src/test/resources/jslint/jslint.properties


### PR DESCRIPTION
This commit added possibility to configure options for JSLint processor using property file. Currently such configuration is not possible although JSLInt API allows this.

I have also added new repo entry in the build file since mavenCentral() seems to download artifiacts from other repository url then "http://central.maven.org/maven2".