### PR TITLE
ReviewFile without starting slash in file name

### DIFF
--- a/src/main/java/pl/touk/sputnik/connector/stash/StashFacade.java
+++ b/src/main/java/pl/touk/sputnik/connector/stash/StashFacade.java
@@ -47,13 +47,23 @@ public class StashFacade implements ConnectorFacade {
 
             List<ReviewFile> files = new ArrayList<>();
             for (ReviewElement container : containers) {
-                String filePath = String.format("%s/%s", container.parent, container.name);
+                String filePath = getFilePath(container);
                 files.add(new ReviewFile(filePath));
             }
             return files;
         } catch (URISyntaxException | IOException e) {
             throw new StashException("Error when listing files", e);
         }
+    }
+
+    private String getFilePath(ReviewElement container) {
+        String filePath;
+        if (container.parent.isEmpty()) {
+            filePath = container.name;
+        } else {
+            filePath = String.format("%s/%s", container.parent, container.name);
+        }
+        return filePath;
     }
 
     @Override

--- a/src/test/java/pl/touk/sputnik/connector/stash/StashFacadeTest.java
+++ b/src/test/java/pl/touk/sputnik/connector/stash/StashFacadeTest.java
@@ -48,7 +48,10 @@ public class StashFacadeTest {
                 FacadeConfigUtil.PATH, SOME_PROJECT_KEY, SOME_REPOSITORY, SOME_PULL_REQUEST_ID)), "/json/stash-changes.json");
 
         List<ReviewFile> files = stashFacade.listFiles();
-        assertThat(files).hasSize(4);
+
+        assertThat(files).extracting("reviewFilename").containsOnly("project/RecoBuild.scala", "project/RecoRelease.scala",
+                "reco-analyzer/src/main/scala/com/allegrogroup/reco/analyzer/spark/ImportUserRecommendationsToCassandraSparkJob.scala",
+                "version.sbt");
     }
 
     @Test


### PR DESCRIPTION
Stash returns Internal Server Error when pull request contatins files located in project root directory (without parent). The cause is slash at the beginning of file name. 

Log:
```
22:32:55.088 [main] INFO  p.t.s.connector.http.HttpConnector - Request 2: GET to http://localhost:7990/rest/api/1.0/projects/PROJ/repos/repo1/pull-requests/1/diff//build.gradle?contextLines=-1&srcPath=%2Fbuild.gradle&withComments=true
22:32:55.388 [main] INFO  p.t.s.connector.http.HttpConnector - Response 2: HTTP/1.1 500 Internal Server Error
22:32:55.394 [main] INFO  p.t.s.connector.http.HttpConnector - Entity 2: {"errors":[{"context":null,"message":"'/usr/bin/git diff -C --color=never -U10 --dst-prefix=dst:// --src-prefix=src:// 5f338d8f4c6a2784c600521f6eb1c9f9b1eef440 b0d949c4204e959100d4d43639601d6e59e142da -- /build.gradle' exited with code 128 saying: fatal: /build.gradle: '/build.gradle' is outside repository","exceptionName":"com.atlassian.stash.exception.CommandFailedException"}]}
Exception in thread "main" com.jayway.jsonpath.PathNotFoundException: Path 'diffs' not found in the current context:
{"errors":[{"context":null,"message":"'\/usr\/bin\/git diff -C --color=never -U10 --dst-prefix=dst:\/\/ --src-prefix=src:\/\/ 5f338d8f4c6a2784c600521f6eb1c9f9b1eef440 b0d949c4204e959100d4d43639601d6e59e142da -- \/build.gradle' exited with code 128 saying: fatal: \/build.gradle: '\/build.gradle' is outside repository","exceptionName":"com.atlassian.stash.exception.CommandFailedException"}]}
```