### PR TITLE
java8 + custom catchException on lambdas

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,8 @@ scmVersion {
 
 project.version = scmVersion.version
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 group = 'pl.touk'
 mainClassName = 'pl.touk.sputnik.Main'
 
@@ -111,7 +111,6 @@ dependencies {
     testCompile 'junit:junit:4.11'
     testCompile 'org.mockito:mockito-all:1.9.5'
     testCompile 'org.assertj:assertj-core:1.5.0'
-    testCompile 'com.googlecode.catch-exception:catch-exception:1.2.0'
     testCompile('com.github.tomakehurst:wiremock:1.46') {
         exclude group: 'log4j'
     }

--- a/src/test/java/pl/touk/sputnik/CatchException.java
+++ b/src/test/java/pl/touk/sputnik/CatchException.java
@@ -1,0 +1,18 @@
+package pl.touk.sputnik;
+
+import org.junit.Assert;
+
+import java.util.function.Consumer;
+
+public class CatchException {
+
+    public static void catchException(Runnable block, Consumer<Exception> consumer) {
+        try {
+            block.run();
+            Assert.fail();
+        } catch (Exception ex) {
+            consumer.accept(ex);
+        }
+    }
+
+}

--- a/src/test/java/pl/touk/sputnik/connector/gerrit/GerritFacadeExceptionTest.java
+++ b/src/test/java/pl/touk/sputnik/connector/gerrit/GerritFacadeExceptionTest.java
@@ -8,11 +8,10 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import static com.googlecode.catchexception.CatchException.catchException;
-import static com.googlecode.catchexception.CatchException.caughtException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static pl.touk.sputnik.CatchException.catchException;
 
 @RunWith(MockitoJUnitRunner.class)
 public class GerritFacadeExceptionTest {
@@ -29,12 +28,12 @@ public class GerritFacadeExceptionTest {
         GerritFacade gerritFacade = new GerritFacade(gerritApi, new GerritPatchset("foo", "bar"));
 
         //when
-        catchException(gerritFacade).listFiles();
+        catchException(gerritFacade::listFiles, (caughtException) ->
 
         //then
-        assertThat(caughtException())
-                .isInstanceOf(GerritException.class)
-                .hasMessageContaining("Error when listing files");
+        assertThat(caughtException)
+                    .isInstanceOf(GerritException.class)
+                    .hasMessageContaining("Error when listing files"));
     }
 
 }

--- a/src/test/java/pl/touk/sputnik/connector/gerrit/GerritFacadeTest.java
+++ b/src/test/java/pl/touk/sputnik/connector/gerrit/GerritFacadeTest.java
@@ -4,9 +4,6 @@ import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import com.google.common.collect.ImmutableMap;
 
-import static com.googlecode.catchexception.CatchException.catchException;
-import static com.googlecode.catchexception.CatchException.caughtException;
-
 import com.google.gerrit.extensions.api.GerritApi;
 import com.google.gerrit.extensions.api.changes.ChangeApi;
 import com.google.gerrit.extensions.api.changes.Changes;
@@ -39,6 +36,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static pl.touk.sputnik.CatchException.catchException;
 
 @RunWith(MockitoJUnitRunner.class)
 public class GerritFacadeTest {
@@ -61,11 +59,11 @@ public class GerritFacadeTest {
 
         // when
         ConnectorFacade gerritFacade = connectionFacade.build(ConnectorType.GERRIT);
-        catchException(gerritFacade).validate(ConfigurationHolder.instance());
+        catchException(() -> gerritFacade.validate(ConfigurationHolder.instance()), (caughtException) ->
 
         // then
-        assertThat(caughtException()).isInstanceOf(GeneralOptionNotSupportedException.class).hasMessage(
-                "This connector does not support global.commentOnlyChangedLines");
+        assertThat(caughtException).isInstanceOf(GeneralOptionNotSupportedException.class).hasMessage(
+                "This connector does not support global.commentOnlyChangedLines"));
     }
 
     @Test

--- a/src/test/java/pl/touk/sputnik/processor/findbugs/FindBugsProcessorTest.java
+++ b/src/test/java/pl/touk/sputnik/processor/findbugs/FindBugsProcessorTest.java
@@ -14,11 +14,10 @@ import pl.touk.sputnik.review.transformer.ClassNameTransformer;
 
 import java.util.List;
 
-import static com.googlecode.catchexception.CatchException.catchException;
-import static com.googlecode.catchexception.CatchException.caughtException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
+import static pl.touk.sputnik.CatchException.catchException;
 
 @RunWith(MockitoJUnitRunner.class)
 public class FindBugsProcessorTest extends TestEnvironment {
@@ -54,10 +53,10 @@ public class FindBugsProcessorTest extends TestEnvironment {
     @Test
     public void shouldThrowWhenFileNotFound() {
         //when
-        catchException(findBugsProcessor).process(nonexistantReview());
+        catchException(() -> findBugsProcessor.process(nonexistantReview()), (caughtException) ->
 
         //then
-        assertThat(caughtException()).isInstanceOf(ReviewException.class);
+        assertThat(caughtException).isInstanceOf(ReviewException.class));
     }
 
 }

--- a/src/test/java/pl/touk/sputnik/processor/pmd/PmdProcessorTest.java
+++ b/src/test/java/pl/touk/sputnik/processor/pmd/PmdProcessorTest.java
@@ -5,9 +5,8 @@ import pl.touk.sputnik.TestEnvironment;
 import pl.touk.sputnik.review.ReviewException;
 import pl.touk.sputnik.review.ReviewResult;
 
-import static com.googlecode.catchexception.CatchException.catchException;
-import static com.googlecode.catchexception.CatchException.caughtException;
 import static org.assertj.core.api.Assertions.assertThat;
+import static pl.touk.sputnik.CatchException.catchException;
 
 public class PmdProcessorTest extends TestEnvironment {
 
@@ -30,10 +29,10 @@ public class PmdProcessorTest extends TestEnvironment {
     @Test
     public void shouldThrowReviewExceptionOnNotFoundFile() {
         // when
-        catchException(fixture).process(nonexistantReview());
+        catchException(() -> fixture.process(nonexistantReview()), (caughtException) ->
 
         // then
-        assertThat(caughtException()).isInstanceOf(ReviewException.class);
+        assertThat(caughtException).isInstanceOf(ReviewException.class));
     }
 
 }


### PR DESCRIPTION
CatchException is not longer needed on Java 8, replaced it with custom implementation