### PR TITLE
Negative line numbers from FindBugs converted to 0.

### DIFF
--- a/src/main/java/pl/touk/sputnik/connector/gerrit/GerritFacade.java
+++ b/src/main/java/pl/touk/sputnik/connector/gerrit/GerritFacade.java
@@ -4,7 +4,9 @@ import com.google.gerrit.extensions.api.GerritApi;
 import com.google.gerrit.extensions.api.changes.ReviewInput;
 import com.google.gerrit.extensions.common.FileInfo;
 import com.google.gerrit.extensions.restapi.RestApiException;
+
 import org.jetbrains.annotations.NotNull;
+
 import pl.touk.sputnik.configuration.Configuration;
 import pl.touk.sputnik.configuration.GeneralOption;
 import pl.touk.sputnik.configuration.GeneralOptionNotSupportedException;
@@ -17,7 +19,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class GerritFacade implements ConnectorFacade {
     private static final String COMMIT_MSG = "/COMMIT_MSG";
 
@@ -60,6 +64,7 @@ public class GerritFacade implements ConnectorFacade {
     @Override
     public void setReview(@NotNull Review review) {
         try {
+            log.debug("Set review in Gerrit: {}", review);
             ReviewInput reviewInput = new ReviewInputBuilder().toReviewInput(review);
             gerritApi.changes().id(gerritPatchset.getChangeId()).revision(gerritPatchset.getRevisionId())
                     .review(reviewInput);

--- a/src/main/java/pl/touk/sputnik/processor/findbugs/CollectorBugReporter.java
+++ b/src/main/java/pl/touk/sputnik/processor/findbugs/CollectorBugReporter.java
@@ -20,8 +20,11 @@ public class CollectorBugReporter extends AbstractBugReporter {
     @Override
     protected void doReportBug(BugInstance bugInstance) {
         SourceLineAnnotation primarySourceLineAnnotation = bugInstance.getPrimarySourceLineAnnotation();
-        Violation violation = new Violation(primarySourceLineAnnotation.getClassName(),
-                primarySourceLineAnnotation.getStartLine(), bugInstance.getMessage(),
+        int line = primarySourceLineAnnotation.getStartLine();
+        if (line < 0) {
+            line = 0;
+        }
+        Violation violation = new Violation(primarySourceLineAnnotation.getClassName(), line, bugInstance.getMessage(),
                 convert(bugInstance.getPriority()));
         log.debug("Violation found: {}", violation);
         reviewResult.add(violation);

--- a/src/main/java/pl/touk/sputnik/review/Comment.java
+++ b/src/main/java/pl/touk/sputnik/review/Comment.java
@@ -2,9 +2,11 @@ package pl.touk.sputnik.review;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
 @AllArgsConstructor
+@ToString
 public class Comment {
     private final int line;
     private final String message;

--- a/src/main/java/pl/touk/sputnik/review/Review.java
+++ b/src/main/java/pl/touk/sputnik/review/Review.java
@@ -2,12 +2,16 @@ package pl.touk.sputnik.review;
 
 import com.google.common.base.Function;
 import com.google.common.collect.Lists;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
 import pl.touk.sputnik.review.filter.FileFilter;
 import pl.touk.sputnik.review.transformer.FileTransformer;
 
@@ -20,6 +24,7 @@ import java.util.Map;
 @Slf4j
 @Getter
 @Setter
+@ToString
 public class Review {
     /* Source, severity, message, e.g. [Checkstyle] Info: This is bad */
     private static final String COMMENT_FORMAT = "[%s] %s: %s";

--- a/src/main/java/pl/touk/sputnik/review/ReviewFile.java
+++ b/src/main/java/pl/touk/sputnik/review/ReviewFile.java
@@ -1,6 +1,8 @@
 package pl.touk.sputnik.review;
 
 import lombok.Getter;
+import lombok.ToString;
+
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
@@ -12,6 +14,7 @@ import java.util.regex.Pattern;
 import static pl.touk.sputnik.review.Paths.*;
 
 @Getter
+@ToString
 public class ReviewFile {
     private static final Pattern ENTRY_PATTERN = Pattern.compile(ENTRY_REGEX);
 


### PR DESCRIPTION
Sometimes FindBugs reports -1 as line number. Passing -1 as line number to Gerrit from Sputnik ends with exception. I've prepared a fix to convert negative line numbers from FindBugs to 0. Comments with line number 0 are treated as comments for entire file in Gerrit.