### PR TITLE
No exception thrown when there are no files to review for FindBugs and PMD.

### DIFF
--- a/src/main/java/pl/touk/sputnik/processor/findbugs/FindBugsProcessor.java
+++ b/src/main/java/pl/touk/sputnik/processor/findbugs/FindBugsProcessor.java
@@ -1,5 +1,7 @@
 package pl.touk.sputnik.processor.findbugs;
 
+import java.util.List;
+
 import edu.umd.cs.findbugs.ClassScreener;
 import edu.umd.cs.findbugs.DetectorFactoryCollection;
 import edu.umd.cs.findbugs.FindBugs2;
@@ -8,9 +10,11 @@ import edu.umd.cs.findbugs.Priorities;
 import edu.umd.cs.findbugs.Project;
 import edu.umd.cs.findbugs.config.UserPreferences;
 import lombok.extern.slf4j.Slf4j;
+
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
 import pl.touk.sputnik.configuration.ConfigurationHolder;
 import pl.touk.sputnik.configuration.GeneralOption;
 import pl.touk.sputnik.review.Review;
@@ -36,6 +40,10 @@ public class FindBugsProcessor implements ReviewProcessor {
     @Nullable
     @Override
     public ReviewResult process(@NotNull Review review) {
+        if (classesToReview(review).isEmpty()) {
+            return null;
+        }
+        
         FindBugs2 findBugs = createFindBugs2(review);
         try {
             findBugs.execute();
@@ -97,10 +105,14 @@ public class FindBugsProcessor implements ReviewProcessor {
     @NotNull
     private IClassScreener createClassScreener(@NotNull Review review) {
         ClassScreener classScreener = new ClassScreener();
-        for (String javaClassName : review.getFiles(new JavaFilter(), new ClassNameTransformer())) {
+        for (String javaClassName : classesToReview(review)) {
             classScreener.addAllowedClass(javaClassName);
         }
         return classScreener;
+    }
+
+    private List<String> classesToReview(@NotNull Review review) {
+        return review.getFiles(new JavaFilter(), new ClassNameTransformer());
     }
 
     @Nullable

--- a/src/main/java/pl/touk/sputnik/processor/pmd/PmdProcessor.java
+++ b/src/main/java/pl/touk/sputnik/processor/pmd/PmdProcessor.java
@@ -1,6 +1,7 @@
 package pl.touk.sputnik.processor.pmd;
 
 import com.google.common.base.Joiner;
+
 import lombok.extern.slf4j.Slf4j;
 import net.sourceforge.pmd.*;
 import net.sourceforge.pmd.benchmark.Benchmark;
@@ -10,8 +11,10 @@ import net.sourceforge.pmd.lang.LanguageVersion;
 import net.sourceforge.pmd.lang.LanguageVersionDiscoverer;
 import net.sourceforge.pmd.renderers.Renderer;
 import net.sourceforge.pmd.util.datasource.DataSource;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
 import pl.touk.sputnik.configuration.ConfigurationHolder;
 import pl.touk.sputnik.configuration.GeneralOption;
 import pl.touk.sputnik.review.Review;
@@ -36,11 +39,16 @@ public class PmdProcessor implements ReviewProcessor {
     @Nullable
     @Override
     public ReviewResult process(@NotNull Review review) {
+        List<String> filesToReview = review.getFiles(new PmdFilter(), new FileNameTransformer());
+        if (filesToReview.isEmpty()) {
+            return null;
+        }
+        
         try {
             PMDConfiguration configuration = new PMDConfiguration();
             configuration.setReportFormat(CollectorRenderer.class.getCanonicalName());
             configuration.setRuleSets(getRulesets());
-            configuration.setInputPaths(Joiner.on(PMD_INPUT_PATH_SEPARATOR).join(review.getFiles(new PmdFilter(), new FileNameTransformer())));
+            configuration.setInputPaths(Joiner.on(PMD_INPUT_PATH_SEPARATOR).join(filesToReview));
             doPMD(configuration);
         } catch (RuntimeException e) {
             log.error("PMD processing error. Something wrong with configuration or analyzed files are not in workspace.", e);

--- a/src/test/java/pl/touk/sputnik/processor/findbugs/FindBugsProcessorTest.java
+++ b/src/test/java/pl/touk/sputnik/processor/findbugs/FindBugsProcessorTest.java
@@ -55,10 +55,21 @@ public class FindBugsProcessorTest extends TestEnvironment {
     @Test
     public void shouldThrowWhenFileNotFound() {
         //when
-        catchException(findBugsProcessor).process(nonexistantReview());
+        catchException(findBugsProcessor).process(nonexistantReview("NotExistingFile.java"));
 
         //then
         assertThat(caughtException()).isInstanceOf(ReviewException.class);
     }
 
+    @Test
+    public void shouldReturnNoReviewWhenNoFilesToReview() {
+        // given
+        Review review = nonexistantReview("FileWithoutJavaExtension.txt");
+
+        // when
+        ReviewResult reviewResult = findBugsProcessor.process(review);
+
+        // then
+        assertThat(reviewResult).isNull();
+    }
 }

--- a/src/test/java/pl/touk/sputnik/processor/pmd/PmdProcessorTest.java
+++ b/src/test/java/pl/touk/sputnik/processor/pmd/PmdProcessorTest.java
@@ -1,10 +1,11 @@
 package pl.touk.sputnik.processor.pmd;
 
 import org.junit.Test;
+
 import pl.touk.sputnik.TestEnvironment;
+import pl.touk.sputnik.review.Review;
 import pl.touk.sputnik.review.ReviewException;
 import pl.touk.sputnik.review.ReviewResult;
-
 import static com.googlecode.catchexception.CatchException.catchException;
 import static com.googlecode.catchexception.CatchException.caughtException;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,10 +31,21 @@ public class PmdProcessorTest extends TestEnvironment {
     @Test
     public void shouldThrowReviewExceptionOnNotFoundFile() {
         // when
-        catchException(fixture).process(nonexistantReview());
+        catchException(fixture).process(nonexistantReview("NotExistingFile.java"));
 
         // then
         assertThat(caughtException()).isInstanceOf(ReviewException.class);
     }
 
+    @Test
+    public void shouldReturnEmptyResultWhenNoFilesToReview() {
+        // given
+        Review review = nonexistantReview("FileWithoutJavaExtension.txt");
+
+        // when
+        ReviewResult reviewResult = fixture.process(review);
+
+        // then
+        assertThat(reviewResult).isNull();
+    }
 }


### PR DESCRIPTION
When there are no files to review in commit (based on extension matching) for FindBugs od PMD processors, there is exception thrown and logged in Sputnik logs:
```
13:10:47.721 [main] ERROR p.t.s.p.findbugs.FindBugsProcessor - FindBugs processing error
java.io.IOException: No files to analyze could be opened
	at edu.umd.cs.findbugs.FindBugs2.execute(FindBugs2.java:276) ~[findbugs-3.0.0.jar:na]
	at pl.touk.sputnik.processor.findbugs.FindBugsProcessor.process(FindBugsProcessor.java:29) ~[sputnik-1.4.0.jar:1.4.0]
	at pl.touk.sputnik.engine.ReviewRunner.review(ReviewRunner.java:24) [sputnik-1.4.0.jar:1.4.0]
	at pl.touk.sputnik.engine.Engine.run(Engine.java:33) [sputnik-1.4.0.jar:1.4.0]
	at pl.touk.sputnik.Main.main(Main.java:37) [sputnik-1.4.0.jar:1.4.0]
13:10:47.722 [main] ERROR pl.touk.sputnik.engine.ReviewRunner - Processor FindBugs error
pl.touk.sputnik.review.ReviewException: FindBugs processing error
	at pl.touk.sputnik.processor.findbugs.FindBugsProcessor.process(FindBugsProcessor.java:32) ~[sputnik-1.4.0.jar:1.4.0]
	at pl.touk.sputnik.engine.ReviewRunner.review(ReviewRunner.java:24) ~[sputnik-1.4.0.jar:1.4.0]
	at pl.touk.sputnik.engine.Engine.run(Engine.java:33) [sputnik-1.4.0.jar:1.4.0]
	at pl.touk.sputnik.Main.main(Main.java:37) [sputnik-1.4.0.jar:1.4.0]
Caused by: java.io.IOException: No files to analyze could be opened
	at edu.umd.cs.findbugs.FindBugs2.execute(FindBugs2.java:276) ~[findbugs-3.0.0.jar:na]
	at pl.touk.sputnik.processor.findbugs.FindBugsProcessor.process(FindBugsProcessor.java:29) ~[sputnik-1.4.0.jar:1.4.0]
	... 3 common frames omitted
```
and such comment is sent to Gerrit: "Perfect!. There is a problem with FindBugs: IOException: No files to analyze could be opened"
It looks funny and suggest there is some problem. I've prepared simple fix -- FindBugs and PMD processors return null review when there are no files to review.