### PR TITLE
Avoid reporting error on Findbugs empty review

### DIFF
--- a/src/main/java/pl/touk/sputnik/processor/findbugs/FindBugsProcessor.java
+++ b/src/main/java/pl/touk/sputnik/processor/findbugs/FindBugsProcessor.java
@@ -59,6 +59,7 @@ public class FindBugsProcessor implements ReviewProcessor {
         findBugs.setDetectorFactoryCollection(DetectorFactoryCollection.instance());
         findBugs.setClassScreener(createClassScreener(review));
         findBugs.setUserPreferences(createUserPreferences());
+        findBugs.setNoClassOk(true);
         return findBugs;
     }
 

--- a/src/test/java/pl/touk/sputnik/processor/findbugs/FindBugsProcessorTest.java
+++ b/src/test/java/pl/touk/sputnik/processor/findbugs/FindBugsProcessorTest.java
@@ -53,12 +53,13 @@ public class FindBugsProcessorTest extends TestEnvironment {
     }
 
     @Test
-    public void shouldThrowWhenFileNotFound() {
+    public void shouldReturnEmptyWhenNoClasses() {
         //when
-        catchException(findBugsProcessor).process(nonexistantReview());
+        ReviewResult reviewResult = findBugsProcessor.process(nonexistantReview());
 
         //then
-        assertThat(caughtException()).isInstanceOf(ReviewException.class);
+        assertThat(reviewResult).isNotNull();
+        assertThat(reviewResult.getViolations()).isEmpty();
     }
 
 }


### PR DESCRIPTION
(Also see https://github.com/TouK/sputnik/issues/69)

The change to global problems collection (https://github.com/TouK/sputnik/commit/75b30e12a1ec6378eaa29853dc539e50ea7bd37d) caused Sputnik to report a problem in cases where FindBugs had no files to check, because FindBugs by default throws IOException in that case. Since FindBugs only checks Java files, this can occur if a commit or pull request includes changes to build files, properties files, or documentation, which does not seem like an error condition.

The previous revision of the FindBugs processor swallowed IOException in this case. Fortunately, FindBugs has a flag that can be set to avoid the exception instead, which is a little cleaner. The result is an empty review.


