### PR TITLE
Initializing ConfigurationHolder in MavenBuildDirLocatorTest

### DIFF
--- a/src/test/java/pl/touk/sputnik/review/locator/MavenBuildDirLocatorTest.java
+++ b/src/test/java/pl/touk/sputnik/review/locator/MavenBuildDirLocatorTest.java
@@ -1,15 +1,22 @@
 package pl.touk.sputnik.review.locator;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.google.common.collect.ImmutableList;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import pl.touk.sputnik.configuration.ConfigurationHolder;
 import pl.touk.sputnik.review.Review;
 import pl.touk.sputnik.review.ReviewFile;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class MavenBuildDirLocatorTest {
 
     private MavenBuildDirLocator locator = new MavenBuildDirLocator();
+
+    @BeforeClass
+    public static void setUp() {
+        ConfigurationHolder.initFromResource("test.properties");
+    }
 
     @Test
     public void shouldReturnTestJavaBuildDirectory() {


### PR DESCRIPTION
Initializing ConfigurationHolder in MavenBuildDirLocatorTest should fix NPE in this test (https://travis-ci.org/TouK/sputnik/builds/56576263). Solution similar to one used in ReviewInputBuilderTest. 

