### PR TITLE
Passing arguments to stash-execute.sh script

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ When stash is build on Bamboo there is no direct way to check which pull
 request id it matches. This is a simple way to find required id. 
 
 Assumptions:
-- there is sputnik's config file in project's root directory
-- user and password are configured in bamboo plan as variables
-  _ecosystem.username_ and _ecosystem.password_
+- there is sputnik's config file named `sputnik.properties` in project's root directory
+- user and password are configured in bamboo plan as variables (e.g. 
+  _ecosystem.username_ and _ecosystem.password_)
 - config file has placeholders for user and password:
 ```properties
 stash.username=<username>
@@ -105,11 +105,11 @@ stash.password=<password>
 ```
 
 With those steps in place you can use a step from
-`contrib/stash-execute.sh`. You need to change the script to match your
-environment - there are three variables to change:
-- stash_host
-- project_key
-- repository_slug
+`contrib/stash-execute.sh`: 
+
+```
+current_branch=${bamboo.repository.branch.name} sputnik_distribution_url=https://github.com/TouK/sputnik/releases/download/sputnik-1.4.0/sputnik-1.4.0.zip stash_password=${bamboo_ecosystem_password} stash_user=${bamboo_ecosystem_username} ./stash-execute.sh
+```
 
 ## Launching with Maven
 

--- a/contrib/stash-execute.sh
+++ b/contrib/stash-execute.sh
@@ -1,21 +1,11 @@
-user="${bamboo_ecosystem_username}"
-password="${bamboo_ecosystem_password}"
-current_branch=${bamboo.repository.branch.name}
-
-sputnik_version="1.2"
-stash_host=???
-project_key=???
-repository_slug=???
-
-echo "current branch is: $current_branch"
-
-
-url="https://$stash_host/rest/api/1.0/projects/$project_key/repos/$repository_slug/pull-requests"
-sputnik_url="https://github.com/TouK/sputnik/releases/download/v$sputnik_version/sputnik-$sputnik_version.zip"
-
-tmp_dir=`mktemp -d`
-
-#############
+#!/usr/bin/env bash
+# check arguments
+for param in current_branch stash_password sputnik_distribution_url stash_user; do
+    if [ -z "${!param}" ]; then
+        echo "Required parameter '$param' is missing! "
+        exit 1
+    fi
+done
 
 case "$current_branch" in
     master|production|release*)
@@ -24,9 +14,40 @@ case "$current_branch" in
         ;;
 esac
 
-tmp_output="$tmp_dir/json"
-curl -s $url -u $user:$password > $tmp_output
+configFile="sputnik.properties"
+if [ ! -e "$configFile" ]; then
+    echo "No $configFile present, exiting. "
+    exit 1
+fi
 
+getProperty() {
+    file=$1
+    propertyKey=$2
+    echo `grep -v '^[[:space:]]*\#' $file | grep "$propertyKey" | tail -1 | cut -d "=" -f2- | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'`
+}
+
+getStashBaseUrl() {
+    https=$(getProperty "$configFile" "connector.useHttps")
+    host=$(getProperty "$configFile" "connector.host")
+    port=$(getProperty "$configFile" "connector.port")
+    path=$(getProperty "$configFile" "connector.path")
+    if [ "$https" == "true" ]; then
+        scheme="https"
+    else
+        scheme="http"
+    fi
+    echo "$scheme://$host:$port$path"
+}
+
+project_key=$(getProperty "$configFile" "connector.projectKey")
+repository_slug=$(getProperty "$configFile" "connector.repositorySlug")
+stash_base_url=$(getStashBaseUrl)
+pull_requests_url="$stash_base_url/rest/api/1.0/projects/$project_key/repos/$repository_slug/pull-requests"
+
+tmp_dir=`mktemp -d`
+
+tmp_output="$tmp_dir/json"
+curl -s $pull_requests_url -u $stash_user:$stash_password > $tmp_output
 
 pyexec() {
     echo "`/usr/bin/python -c 'import sys; exec sys.stdin.read()'`"
@@ -50,25 +71,18 @@ END
 prId=`pullRequestId`
 
 ## download sputnik
-wget -O "$tmp_dir/sputnik.zip" $sputnik_url
+wget -O "$tmp_dir/sputnik.zip" $sputnik_distribution_url
 cd $tmp_dir
 unzip sputnik.zip
 cd -
 
 ## filter properties file
-sed -i -e "s/<username>/$user/; s/<password>/$password/" sputnik.properties
+sed -i -e "s/<username>/$stash_user/; s/<password>/$stash_password/" $configFile
 
 ## run code analysis
-cd ${bamboo.build.working.directory}
-if [ -e "sputnik.properties" ]; then 
-$tmp_dir/sputnik-$sputnik_version/bin/sputnik \
+$tmp_dir/sputnik-*/bin/sputnik \
     --conf sputnik.properties \
     --pullRequestId $prId
 
-else
-  echo "no sputnik.properties present"
-fi
-
 ## cleanup
-
 rm -R $tmp_dir


### PR DESCRIPTION
- allows to pass all arguments to script without the need of modifying this script
- allows to pass Stash username, Stash password and branch (we can use any plain value or bamboo variable)
- you can pass URL to sputnik distribution
- stash_host, project_key, repository_slug are read from `sputnik.properties`
- all checks are done at the beginning (fail-fast)