### PR TITLE
Updated key in example.properties storing ScalaStyle configuration file

### DIFF
--- a/src/main/resources/example.properties
+++ b/src/main/resources/example.properties
@@ -34,7 +34,7 @@ findbugs.includeFilter=
 findbugs.excludeFilter=
 
 scalastyle.enabled=true
-scalastyle.config=
+scalastyle.configurationFile=
 
 codenarc.enabled=true
 codenarc.ruleSets=


### PR DESCRIPTION
According to https://github.com/TouK/sputnik/blob/master/src/main/java/pl/touk/sputnik/configuration/GeneralOption.java#L49 property key is `scalastyle.configurationFile`