### PR TITLE
Fix NPE when running sonar

### DIFF
--- a/src/main/java/pl/touk/sputnik/processor/sonar/SonarResultParser.java
+++ b/src/main/java/pl/touk/sputnik/processor/sonar/SonarResultParser.java
@@ -100,9 +100,6 @@ class SonarResultParser {
         while(it.hasNext()){
             JsonNode componentNode = it.next();
             JsonNode pathNode = componentNode.path("path");
-            if (pathNode.isMissingNode()){
-                continue;
-            }
             JsonNode moduleNode = componentNode.path("moduleKey");
             components.put(componentNode.path("key").asText(),
                     new Component(pathNode.asText(), moduleNode.isMissingNode()?null:moduleNode.asText()));


### PR DESCRIPTION
The getIssueFilePath was also resolving components modules
which are also components), to complete file path.
But only components with "path" were added to components list.
Therefore, if a module didn't have "path". It was not added.
No check was done on whether it was found or not => NPE
FIX : add all components. Components without "path" will have empty
path attribute.