### PR TITLE
Fix passing empty inlude file list to CodeNarc

### DIFF
--- a/src/main/java/pl/touk/sputnik/processor/codenarc/CodeNarcProcessor.java
+++ b/src/main/java/pl/touk/sputnik/processor/codenarc/CodeNarcProcessor.java
@@ -8,6 +8,10 @@ import org.jetbrains.annotations.Nullable;
 import pl.touk.sputnik.review.Review;
 import pl.touk.sputnik.review.ReviewProcessor;
 import pl.touk.sputnik.review.ReviewResult;
+import pl.touk.sputnik.review.filter.GroovyFilter;
+import pl.touk.sputnik.review.transformer.FileNameTransformer;
+
+import java.util.List;
 
 @Slf4j
 public class CodeNarcProcessor implements ReviewProcessor {
@@ -20,16 +24,17 @@ public class CodeNarcProcessor implements ReviewProcessor {
     @Nullable
     @Override
     public ReviewResult process(@NotNull Review review) {
-        if (noFilesToReview(review)) {
+        List<String> reviewFiles = review.getFiles(new GroovyFilter(), new FileNameTransformer());
+        if (noFilesToReview(reviewFiles)) {
             return new ReviewResult();
         }
-        CodeNarcRunner codeNarcRunner = codeNarcRunnerBuilder.prepareCodeNarcRunner(review);
+        CodeNarcRunner codeNarcRunner = codeNarcRunnerBuilder.prepareCodeNarcRunner(reviewFiles);
         Results results = codeNarcRunner.execute();
         return resultParser.parseResults(results);
     }
 
-    private boolean noFilesToReview(Review review) {
-        return review.getFiles().isEmpty();
+    private boolean noFilesToReview(List<String> reviewFiles) {
+        return reviewFiles.isEmpty();
     }
 
 

--- a/src/main/java/pl/touk/sputnik/processor/codenarc/CodeNarcRunnerBuilder.java
+++ b/src/main/java/pl/touk/sputnik/processor/codenarc/CodeNarcRunnerBuilder.java
@@ -5,29 +5,28 @@ import org.codenarc.analyzer.FilesystemSourceAnalyzer;
 import org.codenarc.analyzer.SourceAnalyzer;
 import pl.touk.sputnik.configuration.ConfigurationHolder;
 import pl.touk.sputnik.configuration.GeneralOption;
-import pl.touk.sputnik.review.Review;
-import pl.touk.sputnik.review.filter.GroovyFilter;
-import pl.touk.sputnik.review.transformer.FileNameTransformer;
+
+import java.util.List;
 
 class CodeNarcRunnerBuilder {
-    public CodeNarcRunner prepareCodeNarcRunner(Review review) {
+    public CodeNarcRunner prepareCodeNarcRunner(List<String> reviewFiles) {
         CodeNarcRunner codeNarcRunner = new CodeNarcRunner();
         codeNarcRunner.setRuleSetFiles(ConfigurationHolder.instance().getProperty(GeneralOption.CODE_NARC_RULESET));
-        codeNarcRunner.setSourceAnalyzer(createSourceAnalyzer(review));
+        codeNarcRunner.setSourceAnalyzer(createSourceAnalyzer(reviewFiles));
         return codeNarcRunner;
     }
 
-    private SourceAnalyzer createSourceAnalyzer(Review review) {
+    private SourceAnalyzer createSourceAnalyzer(List<String> reviewFiles) {
         FilesystemSourceAnalyzer sourceAnalyzer = new FilesystemSourceAnalyzer();
         sourceAnalyzer.setBaseDirectory(".");
-        sourceAnalyzer.setIncludes(createFileList(review));
+        sourceAnalyzer.setIncludes(createFileList(reviewFiles));
         sourceAnalyzer.setExcludes(ConfigurationHolder.instance().getProperty(GeneralOption.CODE_NARC_EXCLUDES));
         return sourceAnalyzer;
     }
 
-    private String createFileList(Review review) {
+    private String createFileList(List<String> reviewFiles) {
         StringBuilder stringBuilder = new StringBuilder();
-        for (String filesPath : review.getFiles(new GroovyFilter(), new FileNameTransformer())) {
+        for (String filesPath : reviewFiles) {
             stringBuilder.append("**/").append(filesPath).append(",");
         }
         return stringBuilder.toString();

--- a/src/test/java/pl/touk/sputnik/processor/codenarc/CodeNarcProcessorTest.java
+++ b/src/test/java/pl/touk/sputnik/processor/codenarc/CodeNarcProcessorTest.java
@@ -24,6 +24,8 @@ public class CodeNarcProcessorTest {
     private final String REVIEW_FILE_WITH_ONE_VIOLATION_PER_EACH_SEVERITY = "src/test/resources/codeNarc/testFiles/FileWithOneViolationPerEachLevel.groovy";
     private final String REVIEW_FILE_WITHOUT_VIOLATIONS = "src/test/resources/codeNarc/testFiles/FileWithoutViolations.groovy";
     private final String REVIEW_FILE_WITH_IMPORT_VIOLATION = "src/test/resources/codeNarc/testFiles/FileWithImportViolation.groovy";
+    private final String REVIEW_FILE_WITH_NOT_GROOVY_EXTENSION = "src/test/resources/wrongExtension.java";
+    private final String REVIEW_FILE_WITHOUT_EXTENSION = "src/test/resources/withoutExtension";
 
     @Before
     public void setUp() throws Exception {
@@ -164,6 +166,26 @@ public class CodeNarcProcessorTest {
                 .containsOnly(
                         new Violation(REVIEW_FILE_WITH_ONE_VIOLATION, 5, "EmptyTryBlock: The try block is empty", Severity.WARNING)
                 );
+    }
+
+    @Test
+    public void shouldReturnNoViolationsForFileWithNotGroovyExtension() {
+        Review review = getReview(REVIEW_FILE_WITH_NOT_GROOVY_EXTENSION);
+
+        ReviewResult result = sut.process(review);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getViolations()).isEmpty();
+    }
+
+    @Test
+    public void shouldReturnNoViolationsForFileWithoutExtension() {
+        Review review = getReview(REVIEW_FILE_WITH_NOT_GROOVY_EXTENSION);
+
+        ReviewResult result = sut.process(review);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getViolations()).isEmpty();
     }
 
     private Review getReview(String... filePaths) {


### PR DESCRIPTION
The problem occured when all files to review should be filtered out (all
had wrong extension). And indeed it was happening when include file
list was created, but not before start CodeNarc. When CodeNarc obtains
empty file list, then it includes to analyze all files from base directory.