### PR TITLE
Exclude deleted files from analysis

### DIFF
--- a/src/main/java/pl/touk/sputnik/connector/stash/StashFacade.java
+++ b/src/main/java/pl/touk/sputnik/connector/stash/StashFacade.java
@@ -47,7 +47,7 @@ public class StashFacade implements ConnectorFacade {
     public List<ReviewFile> listFiles() {
         try {
             String response = stashConnector.listFiles();
-            List<JSONObject> jsonList = JsonPath.read(response, "$.values[*].path");
+            List<JSONObject> jsonList = JsonPath.read(response, "$.values[?(@.type != 'DELETE')].path");
             List<ReviewElement> containers = transform(jsonList, ReviewElement.class);
 
             List<ReviewFile> files = new ArrayList<>();
@@ -177,6 +177,6 @@ public class StashFacade implements ConnectorFacade {
 
     @Override
     public void validate(Configuration configuration) throws GeneralOptionNotSupportedException {
-        // all features are suppored by Stash
+        // all features are supported by Stash
     }
 }

--- a/src/test/java/pl/touk/sputnik/connector/stash/StashFacadeTest.java
+++ b/src/test/java/pl/touk/sputnik/connector/stash/StashFacadeTest.java
@@ -107,6 +107,17 @@ public class StashFacadeTest {
                 FacadeConfigUtil.PATH, SOME_PROJECT_KEY, SOME_REPOSITORY, SOME_PULL_REQUEST_ID))));
     }
 
+    @Test
+    public void shouldSkipDeletedFiles() throws Exception {
+        stubGet(urlEqualTo(String.format(
+                "%s/rest/api/1.0/projects/%s/repos/%s/pull-requests/%s/changes",
+                FacadeConfigUtil.PATH, SOME_PROJECT_KEY, SOME_REPOSITORY, SOME_PULL_REQUEST_ID)), "/json/stash-changes-deleted-file.json");
+
+        List<ReviewFile> files = stashFacade.listFiles();
+
+        assertThat(files).extracting("reviewFilename").containsOnly("src/main/java/example/App2.java");
+    }
+
     private void stubGet(UrlMatchingStrategy url, String responseFile) throws Exception {
         stubFor(get(url)
                 .withHeader("Authorization", equalTo("Basic dXNlcjpwYXNz"))

--- a/src/test/resources/json/stash-changes-deleted-file.json
+++ b/src/test/resources/json/stash-changes-deleted-file.json
@@ -1,0 +1,51 @@
+{
+  "fromHash": "a4b4d58e462c3ab246397a4c7881803558c25cba",
+  "toHash": "760b1b3c3a6c858af22b8059fc2ee08aa25a05f2",
+  "values": [
+    {
+      "contentId": "5f0c0040a18dab7dd68c54fc31843a388dceae8a",
+      "path": {
+        "components": [
+          "src",
+          "main",
+          "java",
+          "example",
+          "App.java"
+        ],
+        "parent": "src/main/java/example",
+        "name": "App.java",
+        "extension": "java",
+        "toString": "src/main/java/example/App.java"
+      },
+      "percentUnchanged": -1,
+      "type": "DELETE",
+      "nodeType": "FILE",
+      "srcExecutable": false
+    },
+    {
+      "contentId": "9572c96156cd71d10d4aa36f50500aed31e9f097",
+      "path": {
+        "components": [
+          "src",
+          "main",
+          "java",
+          "example",
+          "App2.java"
+        ],
+        "parent": "src/main/java/example",
+        "name": "App2.java",
+        "extension": "java",
+        "toString": "src/main/java/example/App2.java"
+      },
+      "executable": false,
+      "percentUnchanged": -1,
+      "type": "ADD",
+      "nodeType": "FILE"
+    }
+  ],
+  "size": 2,
+  "isLastPage": true,
+  "start": 0,
+  "limit": 25,
+  "nextPageStart": null
+}


### PR DESCRIPTION
Deleted files in Stash should be excluded. Without this you will get such comments:
> Total 2 violations found. There is a problem with PMD: RuntimeException: File App.java doesn't exist

or

> [Checkstyle] ERROR: File not found!