### PR TITLE
Added file extensions configuration for checkstyle

### DIFF
--- a/src/main/java/pl/touk/sputnik/configuration/GeneralOption.java
+++ b/src/main/java/pl/touk/sputnik/configuration/GeneralOption.java
@@ -36,6 +36,7 @@ public enum GeneralOption implements ConfigurationOption {
 
     CHECKSTYLE_ENABLED("checkstyle.enabled", "Checkstyle enabled", "false"),
     CHECKSTYLE_CONFIGURATION_FILE("checkstyle.configurationFile", "Checkstyle configuration file", "sun_checks.xml"),
+    CHECKSTYLE_FILE_EXTENSIONS("checkstyle.file.extensions","Comma separated file extensions processed by checkstyle","java"),
 
     PMD_ENABLED("pmd.enabled", "PMD enabled", "false"),
     PMD_RULESETS("pmd.ruleSets", "PMD rule sets", "rulesets/java/basic.xml"),


### PR DESCRIPTION
Checkstyle is able to validate any type of file (not only Java), for example using RegexpSingleline module you can check xml or jsp files with specified regex pattern (trailing spaces). Before this change checkstyle processor checks only java files now user can specify supported file types by configure checkstyle.file.extensions property. Default value should be java, but you can easily change it to java, jsp,xml .