### PR TITLE
Fixed #116 Filename was not computed correctly.

### DIFF
--- a/src/main/java/pl/touk/sputnik/processor/sonar/SonarResultParser.java
+++ b/src/main/java/pl/touk/sputnik/processor/sonar/SonarResultParser.java
@@ -120,7 +120,9 @@ class SonarResultParser {
         String file = comp.path;
         if (!Strings.isNullOrEmpty(comp.moduleKey)) {
             Component moduleComp = components.get(comp.moduleKey);
-            file = moduleComp.path + '/' + file;
+            if (!Strings.isNullOrEmpty(moduleComp.path)) {
+                file = moduleComp.path + '/' + file;
+            }
         }
         return file;
     }


### PR DESCRIPTION
The filename was not computed correctly and hence some violations were not reported to Gerrit.