### PR TITLE
Unicode support for branch name in stash-execute.sh

### DIFF
--- a/contrib/stash-execute.sh
+++ b/contrib/stash-execute.sh
@@ -55,6 +55,7 @@ pyexec() {
 
 pullRequestId() {
     pyexec <<END
+# -*- coding: utf-8 -*-
 import json
 from pprint import pprint
 json_data=open('$tmp_output')
@@ -63,7 +64,7 @@ data = json.load(json_data)
 json_data.close()
 
 for pr in data["values"]:
-    if pr["fromRef"]["displayId"] == "$current_branch":
+    if pr["fromRef"]["displayId"] == u"$current_branch":
         print pr["id"]
 END
 }


### PR DESCRIPTION
stash-execute.sh does not work for branches with accented character in name. `json.load` translate strings into unicode (https://docs.python.org/2/library/json.html#json-to-py-table) and comparison between str and unicode fails (`pr["fromRef"]["displayId"] == "$current_branch"`). 