### PR TITLE
Checkstyle bumped to version 6.14.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ dependencies {
     compile 'com.urswolfer.gerrit.client.rest:gerrit-rest-java-client:0.8.5'
 
     // Checkstyle dependencies
-    compile 'com.puppycrawl.tools:checkstyle:6.6'
+    compile 'com.puppycrawl.tools:checkstyle:6.14.1'
 
     // PMD dependencies
     compile('net.sourceforge.pmd:pmd-dist:5.2.1') {

--- a/src/main/java/pl/touk/sputnik/processor/checkstyle/CheckstyleProcessor.java
+++ b/src/main/java/pl/touk/sputnik/processor/checkstyle/CheckstyleProcessor.java
@@ -47,7 +47,7 @@ public class CheckstyleProcessor implements ReviewProcessor {
         Checker checker = createChecker(auditListener);
         try {
             checker.process(files);
-        } catch(CheckstyleException e) {
+        } catch (CheckstyleException e) {
             throw new ReviewException("Unable to process files with Checkstyle", e);
         }
         checker.destroy();

--- a/src/main/java/pl/touk/sputnik/processor/checkstyle/CheckstyleProcessor.java
+++ b/src/main/java/pl/touk/sputnik/processor/checkstyle/CheckstyleProcessor.java
@@ -45,7 +45,11 @@ public class CheckstyleProcessor implements ReviewProcessor {
     private void innerProcess(@NotNull Review review, @NotNull AuditListener auditListener) {
         List<File> files = review.getFiles(new JavaFilter(), new IOFileTransformer());
         Checker checker = createChecker(auditListener);
-        checker.process(files);
+        try {
+            checker.process(files);
+        } catch(CheckstyleException e) {
+            throw new ReviewException("Unable to process files with Checkstyle", e);
+        }
         checker.destroy();
     }
 


### PR DESCRIPTION
Checkstyle needs to be updated to version 6.14.1 because there were new rules and in current version the most recent google style did not work.