### PR TITLE
Fix sonar properties transfer

### DIFF
--- a/src/main/java/pl/touk/sputnik/processor/sonar/SonarRunner.java
+++ b/src/main/java/pl/touk/sputnik/processor/sonar/SonarRunner.java
@@ -55,7 +55,7 @@ public class SonarRunner {
         Properties props = loadBaseProperties();
         setAdditionalProperties(props);
 
-        sonarEmbeddedRunner.globalProperties().putAll(props);
+        sonarEmbeddedRunner.addGlobalProperties(props);
 
         log.info("Sonar configuration: {}", props.toString());
 

--- a/src/test/java/pl/touk/sputnik/processor/sonar/SonarRunnerTest.java
+++ b/src/test/java/pl/touk/sputnik/processor/sonar/SonarRunnerTest.java
@@ -38,7 +38,6 @@ public class SonarRunnerTest {
     @Before
     public void setUp() throws FileNotFoundException {
         config = ConfigurationBuilder.initFromResource("test-sonar.properties");
-        when(sonarRunner.globalProperties()).thenReturn(new Properties());
     }
 
     @After
@@ -58,7 +57,7 @@ public class SonarRunnerTest {
         List<String> files = ImmutableList.of("file");
         SonarRunner runner = new SonarRunner(files, sonarRunner, config);
         runner.run();
-        verify(sonarRunner, times(1)).globalProperties();
+        verify(sonarRunner, times(1)).addGlobalProperties(any(Properties.class));
         verify(sonarRunner).execute();
     }
 


### PR DESCRIPTION
Currently you are writing the props to a safe
copy (clone()) of the actual property list and
thus the properties you are adding
are never written into the actual
instance properties.

Using the proper method for adding the properties
fixes this

Fixes issue:  #136