### PR TITLE
Do not duplicate file comments in Stash

### DIFF
--- a/src/main/java/pl/touk/sputnik/connector/stash/StashFacade.java
+++ b/src/main/java/pl/touk/sputnik/connector/stash/StashFacade.java
@@ -29,6 +29,7 @@ import java.util.List;
 
 @Slf4j
 public class StashFacade implements ConnectorFacade {
+    private static final int FILE_COMMENT_LINE_POSITION = 0;
     private StashConnector stashConnector;
     private ObjectMapper objectMapper = new ObjectMapper();
     private final Configuration configuration;
@@ -165,7 +166,7 @@ public class StashFacade implements ConnectorFacade {
                 for (LineComment lineComment : fileComments) {
                     comments.add(lineComment.text);
                 }
-                changes.addChange(0, ChangeType.NONE, comments);
+                changes.addChange(FILE_COMMENT_LINE_POSITION, ChangeType.NONE, comments);
             }
             return changes;
         } catch (URISyntaxException | IOException e) {

--- a/src/main/java/pl/touk/sputnik/connector/stash/StashFacade.java
+++ b/src/main/java/pl/touk/sputnik/connector/stash/StashFacade.java
@@ -150,13 +150,22 @@ public class StashFacade implements ConnectorFacade {
             String response = stashConnector.getDiffByLine(filename);
             List<JSONObject> diffJsonList = JsonPath.read(response, "$.diffs[*].hunks[*].segments[*]");
             List<JSONObject> lineCommentJsonList = JsonPath.read(response, "$.diffs[*].lineComments[*]['text', 'id']");
+            List<JSONObject> fileCommentJsonList = JsonPath.read(response, "$.diffs[*].fileComments[*]['text', 'id']");
             List<DiffSegment> segments = transform(diffJsonList, DiffSegment.class);
             List<LineComment> lineComments = transform(lineCommentJsonList, LineComment.class);
+            List<LineComment> fileComments = transform(fileCommentJsonList, LineComment.class);
             SingleFileChanges changes = SingleFileChanges.builder().filename(filename).build();
             for (DiffSegment segment : segments) {
                 for (LineSegment line : segment.lines) {
                     changes.addChange(line.destination, ChangeType.valueOf(segment.type), getComment(lineComments, line.commentIds));
                 }
+            }
+            if (!fileComments.isEmpty()) {
+                List<String> comments = new ArrayList<>();
+                for (LineComment lineComment : fileComments) {
+                    comments.add(lineComment.text);
+                }
+                changes.addChange(0, ChangeType.NONE, comments);
             }
             return changes;
         } catch (URISyntaxException | IOException e) {

--- a/src/test/resources/json/stash-changes-for-file-violation.json
+++ b/src/test/resources/json/stash-changes-for-file-violation.json
@@ -1,0 +1,35 @@
+{
+  "fromHash": "f18cca8d4070ad89c4d65bbcee1d74875113819f",
+  "toHash": "646afa05e6c3487eeceb91efb1adde1d568a0256",
+  "values": [
+    {
+      "contentId": "e772f87e63e99dc933113accf2d973610929af6a",
+      "fromContentId": "11ccbe4b07de2e5eaa65fabfb58bfc8bbb32c98c",
+      "path": {
+        "components": [
+          "src",
+          "main",
+          "java",
+          "com",
+          "example",
+          "app",
+          "Runner.java"
+        ],
+        "parent": "src/main/java/com/example/app",
+        "name": "Runner.java",
+        "extension": "java",
+        "toString": "src/main/java/com/example/app/Runner.java"
+      },
+      "executable": false,
+      "percentUnchanged": -1,
+      "type": "MODIFY",
+      "nodeType": "FILE",
+      "srcExecutable": false
+    }
+  ],
+  "size": 1,
+  "isLastPage": true,
+  "start": 0,
+  "limit": 25,
+  "nextPageStart": null
+}

--- a/src/test/resources/json/stash-diff-no-file-comments.json
+++ b/src/test/resources/json/stash-diff-no-file-comments.json
@@ -1,0 +1,106 @@
+{
+  "fromHash": "f18cca8d4070ad89c4d65bbcee1d74875113819f",
+  "toHash": "646afa05e6c3487eeceb91efb1adde1d568a0256",
+  "contextLines": 10,
+  "whitespace": "SHOW",
+  "diffs": [
+    {
+      "source": {
+        "components": [
+          "src",
+          "main",
+          "java",
+          "com",
+          "example",
+          "app",
+          "Runner.java"
+        ],
+        "parent": "src/main/java/com/example/app",
+        "name": "Runner.java",
+        "extension": "java",
+        "toString": "src/main/java/com/example/app/Runner.java"
+      },
+      "destination": {
+        "components": [
+          "src",
+          "main",
+          "java",
+          "com",
+          "example",
+          "app",
+          "Runner.java"
+        ],
+        "parent": "src/main/java/com/example/app",
+        "name": "Runner.java",
+        "extension": "java",
+        "toString": "src/main/java/com/example/app/Runner.java"
+      },
+      "hunks": [
+        {
+          "sourceLine": 1,
+          "sourceSpan": 5,
+          "destinationLine": 1,
+          "destinationSpan": 5,
+          "segments": [
+            {
+              "type": "CONTEXT",
+              "lines": [
+                {
+                  "source": 1,
+                  "destination": 1,
+                  "line": "package com.example.app;",
+                  "truncated": false
+                },
+                {
+                  "source": 2,
+                  "destination": 2,
+                  "line": "",
+                  "truncated": false
+                },
+                {
+                  "source": 3,
+                  "destination": 3,
+                  "line": "public interface Runner {",
+                  "truncated": false
+                },
+                {
+                  "source": 4,
+                  "destination": 4,
+                  "line": "    void run();",
+                  "truncated": false
+                }
+              ],
+              "truncated": false
+            },
+            {
+              "type": "REMOVED",
+              "lines": [
+                {
+                  "source": 5,
+                  "destination": 5,
+                  "line": "}",
+                  "truncated": false
+                }
+              ],
+              "truncated": false
+            },
+            {
+              "type": "ADDED",
+              "lines": [
+                {
+                  "source": 6,
+                  "destination": 5,
+                  "line": "}",
+                  "truncated": false
+                }
+              ],
+              "truncated": false
+            }
+          ],
+          "truncated": false
+        }
+      ],
+      "truncated": false
+    }
+  ]
+}

--- a/src/test/resources/json/stash-diff-with-file-comment.json
+++ b/src/test/resources/json/stash-diff-with-file-comment.json
@@ -1,0 +1,131 @@
+{
+  "fromHash": "f18cca8d4070ad89c4d65bbcee1d74875113819f",
+  "toHash": "646afa05e6c3487eeceb91efb1adde1d568a0256",
+  "contextLines": 10,
+  "whitespace": "SHOW",
+  "diffs": [
+    {
+      "source": {
+        "components": [
+          "src",
+          "main",
+          "java",
+          "com",
+          "example",
+          "app",
+          "Runner.java"
+        ],
+        "parent": "src/main/java/com/example/app",
+        "name": "Runner.java",
+        "extension": "java",
+        "toString": "src/main/java/com/example/app/Runner.java"
+      },
+      "destination": {
+        "components": [
+          "src",
+          "main",
+          "java",
+          "com",
+          "example",
+          "app",
+          "Runner.java"
+        ],
+        "parent": "src/main/java/com/example/app",
+        "name": "Runner.java",
+        "extension": "java",
+        "toString": "src/main/java/com/example/app/Runner.java"
+      },
+      "hunks": [
+        {
+          "sourceLine": 1,
+          "sourceSpan": 5,
+          "destinationLine": 1,
+          "destinationSpan": 5,
+          "segments": [
+            {
+              "type": "CONTEXT",
+              "lines": [
+                {
+                  "source": 1,
+                  "destination": 1,
+                  "line": "package com.example.app;",
+                  "truncated": false
+                },
+                {
+                  "source": 2,
+                  "destination": 2,
+                  "line": "",
+                  "truncated": false
+                },
+                {
+                  "source": 3,
+                  "destination": 3,
+                  "line": "public interface Runner {",
+                  "truncated": false
+                },
+                {
+                  "source": 4,
+                  "destination": 4,
+                  "line": "    void run();",
+                  "truncated": false
+                }
+              ],
+              "truncated": false
+            },
+            {
+              "type": "REMOVED",
+              "lines": [
+                {
+                  "source": 5,
+                  "destination": 5,
+                  "line": "}",
+                  "truncated": false
+                }
+              ],
+              "truncated": false
+            },
+            {
+              "type": "ADDED",
+              "lines": [
+                {
+                  "source": 6,
+                  "destination": 5,
+                  "line": "}",
+                  "truncated": false
+                }
+              ],
+              "truncated": false
+            }
+          ],
+          "truncated": false
+        }
+      ],
+      "truncated": false,
+      "fileComments": [
+        {
+          "id": 225,
+          "version": 0,
+          "text": "[Checkstyle] WARNING: File does not end with a newline.",
+          "author": {
+            "name": "admin",
+            "emailAddress": "admin@example.com",
+            "id": 1,
+            "displayName": "Administrator",
+            "active": true,
+            "slug": "admin",
+            "type": "NORMAL"
+          },
+          "createdDate": 1476558804537,
+          "updatedDate": 1476558804537,
+          "comments": [],
+          "attributes": {},
+          "tasks": [],
+          "permittedOperations": {
+            "editable": true,
+            "deletable": true
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Some Checkstyle's checks (i.e. [NewlineAtEndOfFile](http://checkstyle.sourceforge.net/config_misc.html#NewlineAtEndOfFile)) reports violations at line 0. They become file comments in Stash. These file comments are lot loaded into SingleFileChanges and this cause file comments duplication. 