### PR TITLE
Summary message with singular noun

### DIFF
--- a/src/main/java/pl/touk/sputnik/engine/visitor/SummaryMessageVisitor.java
+++ b/src/main/java/pl/touk/sputnik/engine/visitor/SummaryMessageVisitor.java
@@ -30,7 +30,8 @@ public class SummaryMessageVisitor implements AfterReviewVisitor {
         if (review.getTotalViolationCount() == 0) {
             return perfectMessage;
         }
-        return String.format("Total %d violations found", review.getTotalViolationCount());
+        String violationNoun = review.getTotalViolationCount() == 1 ? "violation" : "violations";
+        return String.format("Total %d %s found", review.getTotalViolationCount(), violationNoun);
     }
 
     private void addProblemMessages(@NotNull Review review) {

--- a/src/test/java/pl/touk/sputnik/engine/visitor/SummaryMessageVisitorTest.java
+++ b/src/test/java/pl/touk/sputnik/engine/visitor/SummaryMessageVisitorTest.java
@@ -24,6 +24,16 @@ public class SummaryMessageVisitorTest extends TestEnvironment {
     }
 
     @Test
+    public void shouldAddSummaryMessageWithOneViolation() {
+        Review review = review();
+        review.setTotalViolationCount(1);
+
+        new SummaryMessageVisitor("Perfect").afterReview(review);
+
+        assertThat(review.getMessages()).containsOnly("Total 1 violation found");
+    }
+
+    @Test
     public void shouldAddPerfectMessageIfThereAreNoViolationsFound() {
         Review review = review();
         review.setTotalViolationCount(0);


### PR DESCRIPTION
Now a summary message for a review with one violation is "Total 1 violation found" instead of "Total 1 violations found". 