### PR TITLE
PMD version bumped to 5.5.2, no NPE in certain cases

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ dependencies {
     compile 'com.puppycrawl.tools:checkstyle:7.3'
 
     // PMD dependencies
-    compile('net.sourceforge.pmd:pmd-java:5.4.1') {
+    compile('net.sourceforge.pmd:pmd-java:5.5.2') {
         exclude group: 'jaxen'
         exclude group: 'xerces'
         exclude group: 'junit'


### PR DESCRIPTION
previous version of PMD had some bug that causes NPE 

`09:09:52.265 [main] ERROR p.t.s.processor.pmd.PmdProcessor - PMD processing error. Something wrong with configuration or analyzed files are not in workspace.
java.util.ConcurrentModificationException: null
	at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:901) ~[na:1.8.0_60]
	at java.util.ArrayList$Itr.next(ArrayList.java:851) ~[na:1.8.0_60]
	at net.sourceforge.pmd.RuleSet.removeDysfunctionalRules(RuleSet.java:530) ~[pmd-core-5.4.1.jar:na]
	at net.sourceforge.pmd.RuleSets.removeDysfunctionalRules(RuleSets.java:203) ~[pmd-core-5.4.1.jar:na]
	at net.sourceforge.pmd.PMD.removeBrokenRules(PMD.java:160) ~[pmd-core-5.4.1.jar:na]
	at net.sourceforge.pmd.PMD.setupReport(PMD.java:139) ~[pmd-core-5.4.1.jar:na]
	at net.sourceforge.pmd.processor.PmdRunnable.call(PmdRunnable.java:66) ~[pmd-core-5.4.1.jar:na]
	at net.sourceforge.pmd.processor.PmdRunnable.call(PmdRunnable.java:25) ~[pmd-core-5.4.1.jar:na]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[na:1.8.0_60]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) ~[na:1.8.0_60]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) ~[na:1.8.0_60]
	at java.lang.Thread.run(Thread.java:745) ~[na:1.8.0_60]
`