### PR TITLE
Do not send -1 as line number from scala style

### DIFF
--- a/src/main/java/pl/touk/sputnik/processor/scalastyle/ScalastyleProcessor.java
+++ b/src/main/java/pl/touk/sputnik/processor/scalastyle/ScalastyleProcessor.java
@@ -76,7 +76,7 @@ public class ScalastyleProcessor implements ReviewProcessor {
             if (msg instanceof StyleError) {
                 StyleError styleError = (StyleError) msg;
                 reviewResult.add(new Violation(currentFileName,
-                        option(styleError.lineNumber(), -1),
+                        option(styleError.lineNumber(), 1),
                         messageHelper.message(styleError.clazz().getClassLoader(), styleError.key(), styleError.args()),
                         errorLevel(styleError.level())));
             }


### PR DESCRIPTION
Sending -1 results in:

```
07:51:17.135 [main] INFO  p.t.s.e.v.score.ScoreAlwaysPass - Adding static passing score {Code-Review=1} to review
Exception in thread "main" pl.touk.sputnik.connector.gerrit.GerritException: Error when setting review
	at pl.touk.sputnik.connector.gerrit.GerritFacade.publish(GerritFacade.java:71)
	at pl.touk.sputnik.engine.Engine.run(Engine.java:47)
	at pl.touk.sputnik.Main.main(Main.java:36)
Caused by: com.urswolfer.gerrit.client.rest.http.HttpStatusException: Request not successful. Message: Bad Request. Status-Code: 400. Content: negative line number -1 not allowed on test/Point.scala.
	at com.urswolfer.gerrit.client.rest.http.GerritRestClient.checkStatusCode(GerritRestClient.java:370)
	at com.urswolfer.gerrit.client.rest.http.GerritRestClient.request(GerritRestClient.java:128)
	at com.urswolfer.gerrit.client.rest.http.GerritRestClient.postRequest(GerritRestClient.java:103)
	at com.urswolfer.gerrit.client.rest.http.changes.RevisionApiRestClient.review(RevisionApiRestClient.java:65)
	at pl.touk.sputnik.connector.gerrit.GerritFacade.publish(GerritFacade.java:69)
	... 2 more
```