### PR TITLE
Gerrit: Set Tag in ReviewInput

### DIFF
--- a/src/main/java/pl/touk/sputnik/connector/gerrit/ReviewInputBuilder.java
+++ b/src/main/java/pl/touk/sputnik/connector/gerrit/ReviewInputBuilder.java
@@ -13,9 +13,12 @@ import java.util.List;
 
 public class ReviewInputBuilder {
 
+    private static final String REVIEW_TAG = "sputnik";
+
     @NotNull
     public ReviewInput toReviewInput(@NotNull Review review) {
         ReviewInput reviewInput = new ReviewInput();
+        reviewInput.tag = REVIEW_TAG;
         reviewInput.message = Joiner.on(". ").join(review.getMessages());
         reviewInput.labels = new HashMap<String, Short>(review.getScores());
         reviewInput.comments = new HashMap<String, List<ReviewInput.CommentInput>>();


### PR DESCRIPTION
By setting the tag in the review, the gerrit user is able
to filter such messages on the change screen.

See also:
https://gerrit-documentation.storage.googleapis.com/Documentation/2.14.1/rest-api-changes.html#review-input