### PR TITLE
Support Pylint 1.8 message-id

### DIFF
--- a/src/main/java/pl/touk/sputnik/processor/pylint/PylintResultParser.java
+++ b/src/main/java/pl/touk/sputnik/processor/pylint/PylintResultParser.java
@@ -50,7 +50,11 @@ class PylintResultParser implements ExternalProcessResultParser {
     }
 
     private String formatViolationMessageFromPylint(PylintMessage message) {
-        return message.getMessage() + " [" + message.getSymbol() + "]";
+        if (message.getMessageId() != null) {
+            return message.getMessage() + " [" + message.getMessageId() + ": " + message.getSymbol() + "]";
+        } else {
+            return message.getMessage() + " [" + message.getSymbol() + "]";
+        }
     }
 
     private Severity pylintMessageTypeToSeverity(String message, String messageType) {

--- a/src/main/java/pl/touk/sputnik/processor/pylint/json/PylintMessage.java
+++ b/src/main/java/pl/touk/sputnik/processor/pylint/json/PylintMessage.java
@@ -1,5 +1,6 @@
 package pl.touk.sputnik.processor.pylint.json;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -14,4 +15,6 @@ public class PylintMessage {
     private String type;
     private String symbol;
     private String module;
+    @JsonProperty(value = "message-id", required = false)
+    private String messageId;
 }

--- a/src/test/java/pl/touk/sputnik/processor/pylint/PylintResultParserTest.java
+++ b/src/test/java/pl/touk/sputnik/processor/pylint/PylintResultParserTest.java
@@ -70,6 +70,24 @@ public class PylintResultParserTest {
     }
 
     @Test
+    public void shouldNotFailOnMessageId() throws IOException, URISyntaxException {
+        // given
+        String response = IOUtils.toString(Resources.getResource("pylint/output-with-message-id.txt").toURI());
+
+        // when
+        List<Violation> violations = pylintResultParser.parse(response);
+
+        // then
+        assertThat(violations).hasSize(1);
+        assertThat(violations)
+                .extracting("severity")
+                .containsExactly(Severity.INFO);
+        assertThat(violations)
+                .extracting("message")
+                .containsExactly("Missing module docstring [C0111: missing-docstring]");
+    }
+
+    @Test
     public void shouldThrowExceptionWhenFatalPylintErrorOccurs() throws IOException, URISyntaxException {
         // given
         String response = IOUtils.toString(Resources.getResource("pylint/output-with-fatal.txt").toURI());

--- a/src/test/resources/pylint/output-with-message-id.txt
+++ b/src/test/resources/pylint/output-with-message-id.txt
@@ -1,0 +1,14 @@
+No config file found, using default configuration
+[
+    {
+        "message": "Missing module docstring",
+        "obj": "",
+        "column": 0,
+        "path": "PythonTest.py",
+        "line": 1,
+        "type": "convention",
+        "symbol": "missing-docstring",
+        "module": "PythonTest",
+        "message-id": "C0111"
+    }
+]


### PR DESCRIPTION
This commit fixes issue #187, by optionally including the message-id in the violation message. This message-id was added in Pylint 1.8 and crashed Sputnik.