### PR TITLE
Extend ESLint functionality

### DIFF
--- a/src/main/java/pl/touk/sputnik/configuration/GeneralOption.java
+++ b/src/main/java/pl/touk/sputnik/configuration/GeneralOption.java
@@ -71,6 +71,8 @@ public enum GeneralOption implements ConfigurationOption {
 
     ESLINT_ENABLED("eslint.enabled", "ESLint enabled", "false"),
     ESLINT_RCFILE("eslint.rcfile", "ESLint rcfile", null),
+    ESLINT_EXECUTABLE("eslint.executable", "ESLint executable", "eslint"),
+    ESLINT_PLUGINS_FOLDER("eslint.pluginsFolder", "ESLint plugin folder", null),
 
     PYLINT_ENABLED("pylint.enabled", "Pylint enabled", "false"),
     PYLINT_RCFILE("pylint.rcfile", "Pylint rcfile", null),

--- a/src/main/java/pl/touk/sputnik/processor/eslint/ESLintExecutor.java
+++ b/src/main/java/pl/touk/sputnik/processor/eslint/ESLintExecutor.java
@@ -8,14 +8,18 @@ import java.util.List;
 
 class ESLintExecutor {
 
-    private static final String ESLINT_EXECUTABLE = "eslint";
     private static final String[] ESLINT_OUTPUT_FORMAT = {"--format", "json"};
     private static final String ESLINT_RCFILE_NAME = "--config";
+    private static final String ESLINT_RESOLVE_PLUGINS_RELATIVE_TO = "--resolve-plugins-relative-to";
 
     private final String eslintRcFile;
+    private final String eslintExecutable;
+    private final String pluginsFolder;
 
-    ESLintExecutor(String eslintRcFile) {
+    ESLintExecutor(String eslintRcFile, String eslintExecutable, String pluginsFolder) {
         this.eslintRcFile = eslintRcFile;
+        this.eslintExecutable = eslintExecutable;
+        this.pluginsFolder = pluginsFolder;
     }
 
     String runOnFile(String filePath) {
@@ -23,8 +27,11 @@ class ESLintExecutor {
     }
 
     private String[] buildParams(String filePath) {
-        List<String> args = Lists.newArrayList(ESLINT_EXECUTABLE);
+        List<String> args = Lists.newArrayList(eslintExecutable);
         args.addAll(Arrays.asList(ESLINT_OUTPUT_FORMAT));
+        if (pluginsFolder != null) {
+            args.addAll(Arrays.asList(ESLINT_RESOLVE_PLUGINS_RELATIVE_TO, pluginsFolder));
+        }
         if (eslintRcFile != null) {
             args.addAll(Arrays.asList(ESLINT_RCFILE_NAME, eslintRcFile));
         }

--- a/src/main/java/pl/touk/sputnik/processor/eslint/ESLintProcessor.java
+++ b/src/main/java/pl/touk/sputnik/processor/eslint/ESLintProcessor.java
@@ -17,7 +17,9 @@ class ESLintProcessor extends ProcessorRunningExternalProcess {
     private final ESLintExecutor executor;
 
     ESLintProcessor(Configuration configuration) {
-        executor = new ESLintExecutor(configuration.getProperty(GeneralOption.ESLINT_RCFILE));
+        executor = new ESLintExecutor(configuration.getProperty(GeneralOption.ESLINT_RCFILE),
+                configuration.getProperty(GeneralOption.ESLINT_EXECUTABLE),
+                configuration.getProperty(GeneralOption.ESLINT_PLUGINS_FOLDER));
     }
 
     @Override

--- a/src/main/java/pl/touk/sputnik/processor/eslint/ESLintResultParser.java
+++ b/src/main/java/pl/touk/sputnik/processor/eslint/ESLintResultParser.java
@@ -1,6 +1,7 @@
 package pl.touk.sputnik.processor.eslint;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import pl.touk.sputnik.processor.eslint.json.FileViolations;
 import pl.touk.sputnik.processor.eslint.json.Message;
@@ -14,7 +15,7 @@ import java.util.List;
 
 class ESLintResultParser implements ExternalProcessResultParser {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     @Override
     public List<Violation> parse(String output) {


### PR DESCRIPTION
- Allow specifying the eslint executable path via the setting
  GeneralOption.ESLINT_EXECUTABLE. This is useful when running a
  non-global install of eslint.

- When specifying an alternative folder, the plugins used by ESLint
  can't be found, as ESLint searches in its working directory. It can
  search in a different directory, specified by https://eslint.org/
  docs/user-guide/command-line-interface#--resolve-plugins-relative-to.
  So, we also allow configuring this folder through
  GeneralOption.ESLINT_PLUGINS_FOLDER.

- Do not crash on ESLint's unknown fields in JSON output.

Closes #216. 