### PR TITLE
Bump Detekt version from 1.0.0-RC14 to 1.8.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -137,10 +137,10 @@ dependencies {
     compile 'com.github.shyiko.ktlint:ktlint-ruleset-standard:0.31.0'
 
     // detekt
-    compile 'io.gitlab.arturbosch.detekt:detekt-core:1.0.0-RC14'
-    compile 'io.gitlab.arturbosch.detekt:detekt-rules:1.0.0-RC14'
+    compile 'io.gitlab.arturbosch.detekt:detekt-core:1.8.0'
+    compile 'io.gitlab.arturbosch.detekt:detekt-rules:1.8.0'
     // dependency only for obtaining default configuration
-    compile 'io.gitlab.arturbosch.detekt:detekt-cli:1.0.0-RC14'
+    compile 'io.gitlab.arturbosch.detekt:detekt-cli:1.8.0'
 
     // transitive dependency that used non-SSL version of Maven Central
     // and version 1.74 that was not found

--- a/src/main/java/pl/touk/sputnik/processor/detekt/DetektProcessor.java
+++ b/src/main/java/pl/touk/sputnik/processor/detekt/DetektProcessor.java
@@ -2,7 +2,7 @@ package pl.touk.sputnik.processor.detekt;
 
 import io.gitlab.arturbosch.detekt.api.Config;
 import io.gitlab.arturbosch.detekt.api.Detektion;
-import io.gitlab.arturbosch.detekt.api.YamlConfig;
+import io.gitlab.arturbosch.detekt.api.internal.YamlConfig;
 import io.gitlab.arturbosch.detekt.cli.ClasspathResourceConverter;
 import io.gitlab.arturbosch.detekt.core.DetektFacade;
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings;
@@ -11,6 +11,7 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.kotlin.config.JvmTarget;
 import pl.touk.sputnik.configuration.Configuration;
 import pl.touk.sputnik.configuration.GeneralOption;
 import pl.touk.sputnik.review.Review;
@@ -77,13 +78,19 @@ public class DetektProcessor implements ReviewProcessor {
         ProcessingSettings processingSettings = new ProcessingSettings(
                 files.stream().map(f -> fileSystem.getPath(f)).collect(Collectors.toList()),
                 config,
-                new ArrayList<>(),
+                null,
                 false,
                 false,
                 new ArrayList<>(),
+                new ArrayList<>(),
+                null,
+                JvmTarget.DEFAULT,
                 executor,
                 printStream,
-                printStream
+                printStream,
+                false,
+                false,
+                new ArrayList<>()
         );
 
         return DetektFacade.Companion.create(processingSettings, new RuleSetLocator(processingSettings).load(), Arrays.asList(new LoggingFileProcessor()));

--- a/src/main/java/pl/touk/sputnik/processor/detekt/LoggingFileProcessor.java
+++ b/src/main/java/pl/touk/sputnik/processor/detekt/LoggingFileProcessor.java
@@ -4,6 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config;
 import io.gitlab.arturbosch.detekt.api.Detektion;
 import io.gitlab.arturbosch.detekt.api.FileProcessListener;
 import io.gitlab.arturbosch.detekt.api.Finding;
+import io.gitlab.arturbosch.detekt.api.SetupContext;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.kotlin.psi.KtFile;
@@ -54,6 +55,11 @@ class LoggingFileProcessor implements FileProcessListener {
 
     @Override
     public void init(Config config) {
+
+    }
+
+    @Override
+    public void init(SetupContext setupContext) {
 
     }
 }

--- a/src/test/java/pl/touk/sputnik/processor/detekt/DetektProcessorTest.java
+++ b/src/test/java/pl/touk/sputnik/processor/detekt/DetektProcessorTest.java
@@ -23,6 +23,7 @@ class DetektProcessorTest {
     private static final String VIOLATIONS_1 = "src/test/resources/detekt/testFiles/Violations1.kt";
     private static final String VIOLATIONS_2 = "src/test/resources/detekt/testFiles/sub/Violations2.kt";
     private static final String VIOLATIONS_3 = "src/test/resources/detekt/testFiles/Violations3.kt";
+    private static final String VIOLATIONS_4 = "src/test/resources/detekt/testFiles/Violations4.kt";
     private static final String REVIEW_GROOVY_FILE = "src/test/resources/codeNarc/testFiles/FileWithOneViolationLevel2.groovy";
 
     private DetektProcessor sut;
@@ -60,6 +61,18 @@ class DetektProcessorTest {
                 .contains(new Violation(VIOLATIONS_3, 3, "[empty-blocks/EmptyClassBlock] Empty block of code detected. As they serve no purpose they should be removed.", Severity.INFO))
                 .contains(new Violation(VIOLATIONS_2, 3, "[style/NewLineAtEndOfFile] Checks whether files end with a line separator.", Severity.INFO))
                 .contains(new Violation(VIOLATIONS_3, 4, "[style/NewLineAtEndOfFile] Checks whether files end with a line separator.", Severity.INFO));
+    }
+
+    @Test
+    void shouldReturnGlobalScopeViolation() {
+        Review review = getReview(VIOLATIONS_4);
+
+        ReviewResult result = sut.process(review);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getViolations())
+                .hasSize(1)
+                .contains(new Violation(VIOLATIONS_4, 7, "[coroutines/GlobalCoroutineUsage] Usage of GlobalScope instance is highly discouraged", Severity.ERROR));
     }
 
     @Test

--- a/src/test/resources/detekt/config/config.yml
+++ b/src/test/resources/detekt/config/config.yml
@@ -140,6 +140,11 @@ complexity:
     excludeStringsWithLessThan5Characters: true
     ignoreStringsRegex: '$^'
 
+coroutines:
+  active: true
+  GlobalCoroutineUsage:
+    active: true
+
 code-smell:
   active: true
   FeatureEnvy:
@@ -225,6 +230,8 @@ style:
     ignoreAnnotation: false
   WildcardImport:
     active: true
+    excludes: []
+    excludeImports: []
   SafeCast:
     active: true
   MaxLineLength:

--- a/src/test/resources/detekt/testFiles/Violations4.kt
+++ b/src/test/resources/detekt/testFiles/Violations4.kt
@@ -1,0 +1,9 @@
+package ktlint.testFiles
+
+import org.jetbrains.kotlin.kotlinx.coroutines.GlobalScope
+
+class Violations4 {
+    fun globalCoroutine() {
+        GlobalScope.launch { delay(0L) }
+    }
+}


### PR DESCRIPTION
RC changelog (https://arturbosch.github.io/detekt/changelog-rc.html)
includes the change from filters to includes/excludes in the rules.
More details on this particular migration are here:
https://arturbosch.github.io/detekt/howto-migratetestpattern.html

Another RC change replaced warningThreshold and failThreshold with
maxIssues, but Sputnik has its own scoring strategy.

Since 1.0.0 (https://arturbosch.github.io/detekt/changelog.html) the
changelog includes nice "notable changes" but no migration that would
cause backward compatibility issue.