### PR TITLE
Bump gerrit-rest-java-client to 0.9.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ dependencies {
     compile 'commons-io:commons-io:2.4'
     compile 'org.eclipse.jgit:org.eclipse.jgit:5.5.1.201910021850-r'
 
-    compile 'com.urswolfer.gerrit.client.rest:gerrit-rest-java-client:0.8.8'
+    compile 'com.urswolfer.gerrit.client.rest:gerrit-rest-java-client:0.9.3'
 
     // Checkstyle dependencies
     compile('com.puppycrawl.tools:checkstyle:8.1') {


### PR DESCRIPTION
This is the highest release of gerrit-rest-java-client atm.
Resolves multiple issues fixed in gerrit-rest-java-client.