### PR TITLE
Improve Gerrit connector usability

### DIFF
--- a/src/main/java/pl/touk/sputnik/configuration/GeneralOption.java
+++ b/src/main/java/pl/touk/sputnik/configuration/GeneralOption.java
@@ -83,6 +83,7 @@ public enum GeneralOption implements ConfigurationOption {
     GITHUB_API_KEY("github.api.key", "Personal access tokens for Github", ""),
 
     GERRIT_USE_HTTP_PASSWORD("gerrit.useHttpPassword", "Use Gerrit's internal password token.", "false"),
+    GERRIT_OMIT_DUPLICATE_COMMENTS("gerrit.omitDuplicateComments", "Avoid publishing same comments for the same patchset.", "true"),
 
     JAVA_SRC_DIR("java.src.dir", "Java root source directory", Paths.SRC_MAIN),
     JAVA_TEST_DIR("java.test.dir", "Java root test directory", Paths.SRC_TEST),

--- a/src/main/java/pl/touk/sputnik/configuration/GeneralOption.java
+++ b/src/main/java/pl/touk/sputnik/configuration/GeneralOption.java
@@ -82,6 +82,8 @@ public enum GeneralOption implements ConfigurationOption {
 
     GITHUB_API_KEY("github.api.key", "Personal access tokens for Github", ""),
 
+    GERRIT_USE_HTTP_PASSWORD("gerrit.useHttpPassword", "Use Gerrit's internal password token.", "false"),
+
     JAVA_SRC_DIR("java.src.dir", "Java root source directory", Paths.SRC_MAIN),
     JAVA_TEST_DIR("java.test.dir", "Java root test directory", Paths.SRC_TEST),
 

--- a/src/main/java/pl/touk/sputnik/connector/gerrit/GerritFacade.java
+++ b/src/main/java/pl/touk/sputnik/connector/gerrit/GerritFacade.java
@@ -1,5 +1,6 @@
 package pl.touk.sputnik.connector.gerrit;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.gerrit.extensions.api.GerritApi;
 import com.google.gerrit.extensions.api.changes.ReviewInput;
 import com.google.gerrit.extensions.api.changes.RevisionApi;
@@ -26,8 +27,10 @@ public class GerritFacade implements ConnectorFacade, ReviewPublisher {
     private static final String COMMIT_MSG = "/COMMIT_MSG";
 
     private final GerritApi gerritApi;
-    private final GerritPatchset gerritPatchset;
-    private final GerritOptions options;
+    @VisibleForTesting
+    final GerritPatchset gerritPatchset;
+    @VisibleForTesting
+    final GerritOptions options;
 
     @NotNull
     @Override

--- a/src/main/java/pl/touk/sputnik/connector/gerrit/GerritFacade.java
+++ b/src/main/java/pl/touk/sputnik/connector/gerrit/GerritFacade.java
@@ -27,6 +27,7 @@ public class GerritFacade implements ConnectorFacade, ReviewPublisher {
 
     private final GerritApi gerritApi;
     private final GerritPatchset gerritPatchset;
+    private final GerritOptions options;
 
     @NotNull
     @Override
@@ -63,6 +64,8 @@ public class GerritFacade implements ConnectorFacade, ReviewPublisher {
         try {
             log.debug("Set review in Gerrit: {}", review);
             ReviewInput reviewInput = new ReviewInputBuilder().toReviewInput(review, gerritPatchset.getTag());
+            reviewInput.omitDuplicateComments = options.isOmitDuplicateComments();
+
             gerritApi.changes()
                     .id(gerritPatchset.getChangeId())
                     .revision(gerritPatchset.getRevisionId())

--- a/src/main/java/pl/touk/sputnik/connector/gerrit/GerritFacadeBuilder.java
+++ b/src/main/java/pl/touk/sputnik/connector/gerrit/GerritFacadeBuilder.java
@@ -19,7 +19,7 @@ import static org.apache.commons.lang3.Validate.notBlank;
 @Slf4j
 public class GerritFacadeBuilder {
 
-    private HttpHelper httpHelper = new HttpHelper();
+    private final HttpHelper httpHelper = new HttpHelper();
 
     @NotNull
     public GerritFacade build(Configuration configuration) {
@@ -34,7 +34,8 @@ public class GerritFacadeBuilder {
 
         log.info("Using Gerrit URL: {}", hostUri);
         GerritAuthData.Basic authData = new GerritAuthData.Basic(hostUri,
-                connectorDetails.getUsername(), connectorDetails.getPassword());
+                connectorDetails.getUsername(), connectorDetails.getPassword(),
+                Boolean.parseBoolean(configuration.getProperty(GeneralOption.GERRIT_USE_HTTP_PASSWORD)));
         GerritApi gerritApi = gerritRestApiFactory.create(authData, new HttpClientBuilderExtension() {
             @Override
             public HttpClientBuilder extend(HttpClientBuilder httpClientBuilder, GerritAuthData authData) {

--- a/src/main/java/pl/touk/sputnik/connector/gerrit/GerritFacadeBuilder.java
+++ b/src/main/java/pl/touk/sputnik/connector/gerrit/GerritFacadeBuilder.java
@@ -3,9 +3,11 @@ package pl.touk.sputnik.connector.gerrit;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.gerrit.extensions.api.GerritApi;
+import com.google.gerrit.extensions.restapi.Url;
 import com.urswolfer.gerrit.client.rest.GerritAuthData;
 import com.urswolfer.gerrit.client.rest.GerritRestApiFactory;
 import com.urswolfer.gerrit.client.rest.http.HttpClientBuilderExtension;
+
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.jetbrains.annotations.NotNull;
@@ -17,9 +19,6 @@ import pl.touk.sputnik.connector.http.HttpHelper;
 
 import static org.apache.commons.lang3.Validate.notBlank;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -75,18 +74,8 @@ public class GerritFacadeBuilder {
             return changeId;
         }
         // To keep the changeId readable, we don't encode '~' (it is not needed according to RFC2396)
+        // See also: ChangesRestClient.id(String, String) and ChangesRestClient.id(String, String, String)
         return StreamSupport.stream(Splitter.on('~').split(changeId).spliterator(), false)
-                .map(GerritFacadeBuilder::safeUrlEncode).collect(Collectors.joining("~"));
-    }
-
-    private static String safeUrlEncode(String stringToEncode) {
-        try {
-            return URLEncoder.encode(stringToEncode, StandardCharsets.UTF_8.name());
-        } catch (UnsupportedEncodingException e) {
-            // Should not happen
-            @SuppressWarnings("deprecation")
-            String fallbackValue = URLEncoder.encode(stringToEncode);
-            return fallbackValue;
-        }
+                .map(Url::encode).collect(Collectors.joining("~"));
     }
 }

--- a/src/main/java/pl/touk/sputnik/connector/gerrit/GerritFacadeBuilder.java
+++ b/src/main/java/pl/touk/sputnik/connector/gerrit/GerritFacadeBuilder.java
@@ -39,10 +39,12 @@ public class GerritFacadeBuilder {
             hostUri += connectorDetails.getPath();
         }
 
+        GerritOptions gerritOptions = GerritOptions.from(configuration);
+
         log.info("Using Gerrit URL: {}", hostUri);
         GerritAuthData.Basic authData = new GerritAuthData.Basic(hostUri,
                 connectorDetails.getUsername(), connectorDetails.getPassword(),
-                Boolean.parseBoolean(configuration.getProperty(GeneralOption.GERRIT_USE_HTTP_PASSWORD)));
+                gerritOptions.isUseHttpPassword());
         GerritApi gerritApi = gerritRestApiFactory.create(authData, new HttpClientBuilderExtension() {
             @Override
             public HttpClientBuilder extend(HttpClientBuilder httpClientBuilder, GerritAuthData authData) {
@@ -52,7 +54,7 @@ public class GerritFacadeBuilder {
             }
         });
 
-        return new GerritFacade(gerritApi, gerritPatchset);
+        return new GerritFacade(gerritApi, gerritPatchset, gerritOptions);
     }
 
     @NotNull

--- a/src/main/java/pl/touk/sputnik/connector/gerrit/GerritOptions.java
+++ b/src/main/java/pl/touk/sputnik/connector/gerrit/GerritOptions.java
@@ -1,0 +1,34 @@
+package pl.touk.sputnik.connector.gerrit;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import pl.touk.sputnik.configuration.Configuration;
+import pl.touk.sputnik.configuration.GeneralOption;
+
+@Data
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GerritOptions {
+    /**
+     * Indicates whether to use Gerrit's internal password token.
+     */
+    private final boolean useHttpPassword;
+    /**
+     * Indicates whether to avoid publishing the same comment again when the review is retriggered
+     * for the same revision.
+     */
+    private final boolean omitDuplicateComments;
+
+    static GerritOptions from(Configuration configuration) {
+        return new GerritOptions(
+                Boolean.parseBoolean(configuration.getProperty(GeneralOption.GERRIT_USE_HTTP_PASSWORD)),
+                Boolean.parseBoolean(configuration.getProperty(GeneralOption.GERRIT_OMIT_DUPLICATE_COMMENTS)));
+    }
+
+    @VisibleForTesting
+    static GerritOptions empty() {
+        return new GerritOptions(false, false);
+    }
+}

--- a/src/test/java/pl/touk/sputnik/connector/gerrit/GerritFacadeBuilderTest.java
+++ b/src/test/java/pl/touk/sputnik/connector/gerrit/GerritFacadeBuilderTest.java
@@ -1,0 +1,62 @@
+package pl.touk.sputnik.connector.gerrit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import pl.touk.sputnik.configuration.CliOption;
+import pl.touk.sputnik.configuration.Configuration;
+import pl.touk.sputnik.configuration.ConfigurationOption;
+import pl.touk.sputnik.configuration.GeneralOption;
+
+@ExtendWith(MockitoExtension.class)
+class GerritFacadeBuilderTest {
+    private static final String CHANGE_ID_WITH_SLASH = "project/subproject~branch/subbranch~changeId";
+    private static final String REVISION_ID = "changeId";
+
+    @Mock
+    private Configuration configuration;
+
+    private GerritFacadeBuilder gerritFacadeBuilder;
+
+    @BeforeEach
+    void setup() {
+        when(configuration.getProperty(any()))
+                .then(invocation -> ((ConfigurationOption)invocation.getArgument(0)).getDefaultValue());
+        configure(CliOption.CHANGE_ID, CHANGE_ID_WITH_SLASH);
+        configure(CliOption.REVISION_ID, REVISION_ID);
+
+        gerritFacadeBuilder = new GerritFacadeBuilder();
+    }
+
+    @Test
+    void build_shouldEscapeChangeIdWithSlash() {
+        GerritFacade connector = gerritFacadeBuilder.build(configuration);
+
+        assertEquals("project%2Fsubproject~branch%2Fsubbranch~changeId", connector.gerritPatchset.getChangeId());
+        assertEquals(REVISION_ID, connector.gerritPatchset.getRevisionId());
+    }
+
+    @Test
+    void build_optionsPassed() {
+        configure(GeneralOption.GERRIT_USE_HTTP_PASSWORD, "true");
+        configure(GeneralOption.GERRIT_OMIT_DUPLICATE_COMMENTS, "false");
+
+        GerritFacade connector = gerritFacadeBuilder.build(configuration);
+
+        assertTrue(connector.options.isUseHttpPassword());
+        assertFalse(connector.options.isOmitDuplicateComments());
+    }
+
+    public void configure(ConfigurationOption option, String value) {
+        when(configuration.getProperty(option)).thenReturn(value);
+    }
+}

--- a/src/test/java/pl/touk/sputnik/connector/gerrit/GerritFacadeBuilderTest.java
+++ b/src/test/java/pl/touk/sputnik/connector/gerrit/GerritFacadeBuilderTest.java
@@ -1,8 +1,6 @@
 package pl.touk.sputnik.connector.gerrit;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -38,25 +36,27 @@ class GerritFacadeBuilderTest {
     }
 
     @Test
-    void build_shouldEscapeChangeIdWithSlash() {
+    void shouldEscapeChangeIdWithSlash() {
         GerritFacade connector = gerritFacadeBuilder.build(configuration);
 
-        assertEquals("project%2Fsubproject~branch%2Fsubbranch~changeId", connector.gerritPatchset.getChangeId());
-        assertEquals(REVISION_ID, connector.gerritPatchset.getRevisionId());
+        assertThat(connector.gerritPatchset.getChangeId())
+                .isEqualTo("project%2Fsubproject~branch%2Fsubbranch~changeId");
+        assertThat(connector.gerritPatchset.getRevisionId())
+                .isEqualTo(REVISION_ID);
     }
 
     @Test
-    void build_optionsPassed() {
+    void shouldBuildWithCorrectOptions() {
         configure(GeneralOption.GERRIT_USE_HTTP_PASSWORD, "true");
         configure(GeneralOption.GERRIT_OMIT_DUPLICATE_COMMENTS, "false");
 
         GerritFacade connector = gerritFacadeBuilder.build(configuration);
 
-        assertTrue(connector.options.isUseHttpPassword());
-        assertFalse(connector.options.isOmitDuplicateComments());
+        assertThat(connector.options.isUseHttpPassword()).isTrue();
+        assertThat(connector.options.isOmitDuplicateComments()).isFalse();
     }
 
-    public void configure(ConfigurationOption option, String value) {
+    private void configure(ConfigurationOption option, String value) {
         when(configuration.getProperty(option)).thenReturn(value);
     }
 }

--- a/src/test/java/pl/touk/sputnik/connector/gerrit/GerritFacadeExceptionTest.java
+++ b/src/test/java/pl/touk/sputnik/connector/gerrit/GerritFacadeExceptionTest.java
@@ -2,6 +2,8 @@ package pl.touk.sputnik.connector.gerrit;
 
 import com.google.gerrit.extensions.api.GerritApi;
 import com.google.gerrit.extensions.api.changes.Changes;
+import com.google.gerrit.extensions.restapi.RestApiException;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -10,6 +12,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+
+import pl.touk.sputnik.review.Review;
 
 @ExtendWith(MockitoExtension.class)
 class GerritFacadeExceptionTest {
@@ -25,7 +31,7 @@ class GerritFacadeExceptionTest {
     private Changes changes;
 
     @Test
-    void shouldWrapConnectorException() throws Exception {
+    void listFiles_shouldWrapConnectorException() throws Exception {
         when(gerritApi.changes()).thenReturn(changes);
         when(changes.id(CHANGE_ID)).thenThrow(new RuntimeException("Connection refused"));
         GerritFacade gerritFacade = new GerritFacade(gerritApi, new GerritPatchset(CHANGE_ID, REVISION_ID, TAG), GerritOptions.empty());
@@ -37,4 +43,29 @@ class GerritFacadeExceptionTest {
                 .hasMessageContaining("Error when listing files");
     }
 
+    @Test
+    void publish_shouldWrapConnectorException() throws Exception {
+        when(gerritApi.changes()).thenReturn(changes);
+        when(changes.id(CHANGE_ID)).thenThrow(new RuntimeException("Connection refused"));
+        GerritFacade gerritFacade = new GerritFacade(gerritApi, new GerritPatchset(CHANGE_ID, REVISION_ID, TAG), GerritOptions.empty());
+
+        Throwable thrown = catchThrowable(() -> gerritFacade.publish(new Review(new ArrayList<>(), null)));
+
+        assertThat(thrown)
+                .isInstanceOf(GerritException.class)
+                .hasMessageContaining("Error when setting review");
+    }
+
+    @Test
+    void getRevision_shouldWrapRestApiException() throws Exception {
+        when(gerritApi.changes()).thenReturn(changes);
+        when(changes.id(CHANGE_ID)).thenThrow(RestApiException.wrap("Connection refused", new RuntimeException("Something bad happened")));
+        GerritFacade gerritFacade = new GerritFacade(gerritApi, new GerritPatchset(CHANGE_ID, REVISION_ID, TAG), GerritOptions.empty());
+
+        Throwable thrown = catchThrowable(gerritFacade::getRevision);
+
+        assertThat(thrown)
+                .isInstanceOf(GerritException.class)
+                .hasMessageContaining("Error when retrieve modified lines");
+    }
 }

--- a/src/test/java/pl/touk/sputnik/connector/gerrit/GerritFacadeExceptionTest.java
+++ b/src/test/java/pl/touk/sputnik/connector/gerrit/GerritFacadeExceptionTest.java
@@ -28,7 +28,7 @@ class GerritFacadeExceptionTest {
     void shouldWrapConnectorException() throws Exception {
         when(gerritApi.changes()).thenReturn(changes);
         when(changes.id(CHANGE_ID)).thenThrow(new RuntimeException("Connection refused"));
-        GerritFacade gerritFacade = new GerritFacade(gerritApi, new GerritPatchset(CHANGE_ID, REVISION_ID, TAG));
+        GerritFacade gerritFacade = new GerritFacade(gerritApi, new GerritPatchset(CHANGE_ID, REVISION_ID, TAG), GerritOptions.empty());
 
         Throwable thrown = catchThrowable(gerritFacade::listFiles);
 

--- a/src/test/java/pl/touk/sputnik/connector/gerrit/GerritFacadeTest.java
+++ b/src/test/java/pl/touk/sputnik/connector/gerrit/GerritFacadeTest.java
@@ -5,6 +5,7 @@ import com.google.common.io.Resources;
 import com.google.gerrit.extensions.api.GerritApi;
 import com.google.gerrit.extensions.api.changes.ChangeApi;
 import com.google.gerrit.extensions.api.changes.Changes;
+import com.google.gerrit.extensions.api.changes.ReviewInput;
 import com.google.gerrit.extensions.api.changes.RevisionApi;
 import com.google.gerrit.extensions.common.FileInfo;
 import com.google.gerrit.extensions.restapi.RestApiException;
@@ -14,16 +15,31 @@ import com.google.gson.JsonParser;
 import com.urswolfer.gerrit.client.rest.http.changes.FileInfoParser;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import pl.touk.sputnik.configuration.Configuration;
+import pl.touk.sputnik.review.Review;
 import pl.touk.sputnik.review.ReviewFile;
+import pl.touk.sputnik.review.ReviewFormatter;
+
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 @ExtendWith(MockitoExtension.class)
 class GerritFacadeTest {
@@ -34,6 +50,10 @@ class GerritFacadeTest {
 
     @Mock
     private GerritApi gerritApi;
+    @Mock
+    private GerritOptions gerritOptions;
+    @Mock
+    private Configuration configuration;
 
     @Test
     void shouldParseListFilesResponse() throws IOException, RestApiException {
@@ -47,6 +67,36 @@ class GerritFacadeTest {
         assertThat(reviewFiles).hasSize(1);
     }
 
+    @Test
+    void publish() throws IOException, RestApiException {
+        when(gerritOptions.isOmitDuplicateComments()).thenReturn(true);
+        Review review = new Review(new ArrayList<>(), new ReviewFormatter(configuration));
+        ArgumentCaptor<ReviewInput> reviewInputCaptor = ArgumentCaptor.forClass(ReviewInput.class);
+
+        createGerritFacade().publish(review);
+
+        verify(gerritApi.changes().id(CHANGE_ID).revision(REVISION_ID)).review(reviewInputCaptor.capture());
+        ReviewInput reviewInput = reviewInputCaptor.getValue();
+        assertTrue(reviewInput.omitDuplicateComments);
+        assertEquals(TAG, reviewInput.tag);
+    }
+
+    @Test
+    void getRevision() throws IOException, RestApiException {
+        GerritFacade gerritFacade = createGerritFacade();
+
+        assertSame(gerritApi.changes().id(CHANGE_ID).revision(REVISION_ID), gerritFacade.getRevision());
+    }
+
+    @Test
+    void setReview_doesPublish() throws IOException, RestApiException {
+        Review review = new Review(new ArrayList<>(), new ReviewFormatter(configuration));
+
+        createGerritFacade().setReview(review);
+
+        verify(gerritApi.changes().id(CHANGE_ID).revision(REVISION_ID)).review(any());
+    }
+
     private GerritFacade createGerritFacade() throws IOException, RestApiException {
         @SuppressWarnings("UnstableApiUsage")
         String listFilesJson = Resources.toString(Resources.getResource("json/gerrit-listfiles.json"), Charsets.UTF_8);
@@ -57,10 +107,9 @@ class GerritFacadeTest {
         when(gerritApi.changes()).thenReturn(changes);
         ChangeApi changeApi = mock(ChangeApi.class);
         when(changes.id(CHANGE_ID)).thenReturn(changeApi);
-        RevisionApi revisionApi = mock(RevisionApi.class);
+        RevisionApi revisionApi = mock(RevisionApi.class, withSettings().lenient());
         when(changeApi.revision(REVISION_ID)).thenReturn(revisionApi);
         when(revisionApi.files()).thenReturn(fileInfoMap);
-        return new GerritFacade(gerritApi, new GerritPatchset(CHANGE_ID, REVISION_ID, TAG), GerritOptions.empty());
+        return new GerritFacade(gerritApi, new GerritPatchset(CHANGE_ID, REVISION_ID, TAG), gerritOptions);
     }
-
 }

--- a/src/test/java/pl/touk/sputnik/connector/gerrit/GerritFacadeTest.java
+++ b/src/test/java/pl/touk/sputnik/connector/gerrit/GerritFacadeTest.java
@@ -30,12 +30,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -68,7 +63,7 @@ class GerritFacadeTest {
     }
 
     @Test
-    void publish() throws IOException, RestApiException {
+    void shouldCallGerritApiOnPublish() throws IOException, RestApiException {
         when(gerritOptions.isOmitDuplicateComments()).thenReturn(true);
         Review review = new Review(new ArrayList<>(), new ReviewFormatter(configuration));
         ArgumentCaptor<ReviewInput> reviewInputCaptor = ArgumentCaptor.forClass(ReviewInput.class);
@@ -76,20 +71,20 @@ class GerritFacadeTest {
         createGerritFacade().publish(review);
 
         verify(gerritApi.changes().id(CHANGE_ID).revision(REVISION_ID)).review(reviewInputCaptor.capture());
-        ReviewInput reviewInput = reviewInputCaptor.getValue();
-        assertTrue(reviewInput.omitDuplicateComments);
-        assertEquals(TAG, reviewInput.tag);
+        assertThat(reviewInputCaptor.getValue().omitDuplicateComments).isTrue();
+        assertThat(reviewInputCaptor.getValue().tag).isEqualTo(TAG);
     }
 
     @Test
-    void getRevision() throws IOException, RestApiException {
+    void shouldRevisionApiBeConfigured() throws IOException, RestApiException {
         GerritFacade gerritFacade = createGerritFacade();
 
-        assertSame(gerritApi.changes().id(CHANGE_ID).revision(REVISION_ID), gerritFacade.getRevision());
+        assertThat(gerritFacade.getRevision())
+                .isEqualTo(gerritApi.changes().id(CHANGE_ID).revision(REVISION_ID));
     }
 
     @Test
-    void setReview_doesPublish() throws IOException, RestApiException {
+    void shouldReviewDelegateToPublish() throws IOException, RestApiException {
         Review review = new Review(new ArrayList<>(), new ReviewFormatter(configuration));
 
         createGerritFacade().setReview(review);

--- a/src/test/java/pl/touk/sputnik/connector/gerrit/GerritFacadeTest.java
+++ b/src/test/java/pl/touk/sputnik/connector/gerrit/GerritFacadeTest.java
@@ -12,13 +12,11 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import com.urswolfer.gerrit.client.rest.http.changes.FileInfoParser;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import pl.touk.sputnik.review.ReviewFile;
-
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -37,13 +35,6 @@ class GerritFacadeTest {
     @Mock
     private GerritApi gerritApi;
 
-    private GerritFacade gerritFacade;
-
-    @BeforeEach
-    void setUp() {
-        gerritFacade = new GerritFacade(gerritApi, null);
-    }
-
     @Test
     void shouldParseListFilesResponse() throws IOException, RestApiException {
         List<ReviewFile> reviewFiles = createGerritFacade().listFiles();
@@ -57,6 +48,7 @@ class GerritFacadeTest {
     }
 
     private GerritFacade createGerritFacade() throws IOException, RestApiException {
+        @SuppressWarnings("UnstableApiUsage")
         String listFilesJson = Resources.toString(Resources.getResource("json/gerrit-listfiles.json"), Charsets.UTF_8);
         JsonElement jsonElement = new JsonParser().parse(listFilesJson);
         Map<String, FileInfo> fileInfoMap = new FileInfoParser(new Gson()).parseFileInfos(jsonElement);
@@ -68,7 +60,7 @@ class GerritFacadeTest {
         RevisionApi revisionApi = mock(RevisionApi.class);
         when(changeApi.revision(REVISION_ID)).thenReturn(revisionApi);
         when(revisionApi.files()).thenReturn(fileInfoMap);
-        return new GerritFacade(gerritApi, new GerritPatchset(CHANGE_ID, REVISION_ID, TAG));
+        return new GerritFacade(gerritApi, new GerritPatchset(CHANGE_ID, REVISION_ID, TAG), GerritOptions.empty());
     }
 
 }

--- a/src/test/java/pl/touk/sputnik/connector/gerrit/GerritOptionsTest.java
+++ b/src/test/java/pl/touk/sputnik/connector/gerrit/GerritOptionsTest.java
@@ -1,10 +1,10 @@
 package pl.touk.sputnik.connector.gerrit;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
-import java.util.Properties;
+import static pl.touk.sputnik.configuration.GeneralOption.GERRIT_OMIT_DUPLICATE_COMMENTS;
+import static pl.touk.sputnik.configuration.GeneralOption.GERRIT_USE_HTTP_PASSWORD;
 
 import org.junit.jupiter.api.Test;
 
@@ -14,15 +14,27 @@ import pl.touk.sputnik.configuration.GeneralOption;
 class GerritOptionsTest {
 
     @Test
-    void useHttpPassword() {
-        assertFalse(optionsFrom(GeneralOption.GERRIT_USE_HTTP_PASSWORD, "false").isUseHttpPassword());
-        assertTrue(optionsFrom(GeneralOption.GERRIT_USE_HTTP_PASSWORD, "true").isUseHttpPassword());
+    void shouldHttpPasswordOptionBeConsidered() {
+        assertThat(optionsFrom(GERRIT_USE_HTTP_PASSWORD, "false").isUseHttpPassword())
+                .isFalse();
+        assertThat(optionsFrom(GERRIT_USE_HTTP_PASSWORD, "true").isUseHttpPassword())
+                .isTrue();
     }
 
     @Test
-    void omitDuplicateComments() {
-        assertFalse(optionsFrom(GeneralOption.GERRIT_OMIT_DUPLICATE_COMMENTS, "false").isOmitDuplicateComments());
-        assertTrue(optionsFrom(GeneralOption.GERRIT_OMIT_DUPLICATE_COMMENTS, "true").isOmitDuplicateComments());
+    void shouldOmitDumplicateCommentsOptionBeConsidered() {
+        assertThat(optionsFrom(GERRIT_OMIT_DUPLICATE_COMMENTS, "false").isOmitDuplicateComments())
+                .isFalse();
+        assertThat(optionsFrom(GERRIT_OMIT_DUPLICATE_COMMENTS, "true").isOmitDuplicateComments())
+                .isTrue();
+    }
+
+    @Test
+    void shouldDisableOptionalFeaturesByDefault() {
+        GerritOptions defaultOptions = GerritOptions.from(mock(Configuration.class));
+
+        assertThat(defaultOptions.isOmitDuplicateComments()).isFalse();
+        assertThat(defaultOptions.isUseHttpPassword()).isFalse();
     }
 
     private GerritOptions optionsFrom(GeneralOption option, String value) {

--- a/src/test/java/pl/touk/sputnik/connector/gerrit/GerritOptionsTest.java
+++ b/src/test/java/pl/touk/sputnik/connector/gerrit/GerritOptionsTest.java
@@ -1,0 +1,38 @@
+package pl.touk.sputnik.connector.gerrit;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+
+import pl.touk.sputnik.configuration.Configuration;
+import pl.touk.sputnik.configuration.GeneralOption;
+
+class GerritOptionsTest {
+
+    @Test
+    void useHttpPassword() {
+        assertFalse(optionsFrom(GeneralOption.GERRIT_USE_HTTP_PASSWORD, "false").isUseHttpPassword());
+        assertTrue(optionsFrom(GeneralOption.GERRIT_USE_HTTP_PASSWORD, "true").isUseHttpPassword());
+    }
+
+    @Test
+    void omitDuplicateComments() {
+        assertFalse(optionsFrom(GeneralOption.GERRIT_OMIT_DUPLICATE_COMMENTS, "false").isOmitDuplicateComments());
+        assertTrue(optionsFrom(GeneralOption.GERRIT_OMIT_DUPLICATE_COMMENTS, "true").isOmitDuplicateComments());
+    }
+
+    private GerritOptions optionsFrom(GeneralOption option, String value) {
+        return GerritOptions.from(configure(option, value));
+    }
+
+    private Configuration configure(GeneralOption option, String value) {
+        Configuration configuration = mock(Configuration.class);
+        when(configuration.getProperty(option)).thenReturn(value);
+        return configuration;
+    }
+
+}

--- a/src/test/java/pl/touk/sputnik/connector/gerrit/ReviewInputBuilderTest.java
+++ b/src/test/java/pl/touk/sputnik/connector/gerrit/ReviewInputBuilderTest.java
@@ -18,7 +18,7 @@ class ReviewInputBuilderTest {
 
     private static final String TAG = "ci";
 
-    private ReviewInputBuilder reviewInputBuilder = new ReviewInputBuilder();
+    private final ReviewInputBuilder reviewInputBuilder = new ReviewInputBuilder();
 
     @Test
     void shouldBuildReviewInput() {


### PR DESCRIPTION
Allow usage of Gerrit HTTP password tokens (#220)
URL encode changeId when creating GerritPatchset (#221)
Support gerrit configuration to omit duplicate comments (#108)