### PR TITLE
Use explicit checkstyle configuration for tests

### DIFF
--- a/src/test/java/pl/touk/sputnik/processor/checkstyle/CheckstyleProcessorTest.java
+++ b/src/test/java/pl/touk/sputnik/processor/checkstyle/CheckstyleProcessorTest.java
@@ -1,8 +1,14 @@
 package pl.touk.sputnik.processor.checkstyle;
 
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableMap;
+
 import pl.touk.sputnik.TestEnvironment;
+import pl.touk.sputnik.configuration.ConfigurationSetup;
+import pl.touk.sputnik.configuration.GeneralOption;
 import pl.touk.sputnik.review.ReviewResult;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -12,7 +18,9 @@ class CheckstyleProcessorTest extends TestEnvironment {
     private CheckstyleProcessor fixture;
 
     @BeforeEach
-    void setUp() throws Exception {
+    void setUp() {
+        config = new ConfigurationSetup().setUp(ImmutableMap.of(
+                GeneralOption.CHECKSTYLE_CONFIGURATION_FILE.getKey(), "src/test/resources/checkstyle/checkstyle.xml"));
         fixture = new CheckstyleProcessor(config);
     }
 
@@ -30,5 +38,4 @@ class CheckstyleProcessorTest extends TestEnvironment {
                         "Missing a Javadoc comment."
                 );
     }
-
 }

--- a/src/test/resources/checkstyle/checkstyle.xml
+++ b/src/test/resources/checkstyle/checkstyle.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN" "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="NewlineAtEndOfFile">
+        <property name="lineSeparator" value="lf"/>
+    </module>
+    <module name="JavadocPackage"/>
+
+    <module name="TreeWalker">
+        <!-- Javadoc Comments -->
+        <module name="AtclauseOrder"/>
+        <module name="JavadocMethod">
+            <property name="allowUndeclaredRTE" value="true"/>
+            <property name="allowThrowsTagsForSubclasses" value="true"/>
+            <property name="allowMissingPropertyJavadoc" value="true"/>
+        </module>
+        <module name="JavadocParagraph"/>
+        <module name="JavadocStyle">
+            <property name="scope" value="public"/>
+        </module>
+        <module name="JavadocTagContinuationIndentation"/>
+        <module name="JavadocType">
+            <property name="authorFormat" value="\S"/>
+            <!-- avoid errors on tag '@noinspection' -->
+            <property name="allowUnknownTags" value="true"/>
+        </module>
+        <module name="JavadocVariable"/>
+        <module name="NonEmptyAtclauseDescription"/>
+        <module name="SingleLineJavadoc"/>
+        <module name="SummaryJavadoc"/>
+    </module>
+</module>


### PR DESCRIPTION
Tests failed on Windows systems as the test file uses LF ending.