### PR TITLE
Allow loading of Spotbugs properties from external file

### DIFF
--- a/src/main/java/pl/touk/sputnik/configuration/GeneralOption.java
+++ b/src/main/java/pl/touk/sputnik/configuration/GeneralOption.java
@@ -45,10 +45,12 @@ public enum GeneralOption implements ConfigurationOption {
     PMD_SHOW_VIOLATION_DETAILS("pmd.showViolationDetails", "Show violation details and URL", "false"),
 
     FINDBUGS_ENABLED("findbugs.enabled", "FindBugs enabled", "false"),
+    FINDBUGS_LOAD_PROPERTIES_FROM("findbugs.loadPropertiesFrom", "FindBugs properties file", ""),
     FINDBUGS_INCLUDE_FILTER("findbugs.includeFilter", "FindBugs include filter file", ""),
     FINDBUGS_EXCLUDE_FILTER("findbugs.excludeFilter", "FindBugs exclude filter file", ""),
 
     SPOTBUGS_ENABLED("spotbugs.enabled", "SpotBugs enabled", "false"),
+    SPOTBUGS_LOAD_PROPERTIES_FROM("spotbugs.loadPropertiesFrom", "SpotBugs properties file", ""),
     SPOTBUGS_INCLUDE_FILTER("spotbugs.includeFilter", "SpotBugs include filter file", ""),
     SPOTBUGS_EXCLUDE_FILTER("spotbugs.excludeFilter", "SpotBugs exclude filter file", ""),
 

--- a/src/test/java/pl/touk/sputnik/processor/spotbugs/SpotBugsProcessorTest.java
+++ b/src/test/java/pl/touk/sputnik/processor/spotbugs/SpotBugsProcessorTest.java
@@ -4,6 +4,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import edu.umd.cs.findbugs.SystemProperties;
 import pl.touk.sputnik.TestEnvironment;
 import pl.touk.sputnik.configuration.ConfigurationSetup;
 import pl.touk.sputnik.configuration.GeneralOption;
@@ -24,7 +26,10 @@ class SpotBugsProcessorTest extends TestEnvironment {
 
     @BeforeEach
     void setUp() {
-        config = new ConfigurationSetup().setUp(ImmutableMap.of(GeneralOption.BUILD_TOOL.getKey(), GRADLE));
+        config = new ConfigurationSetup().setUp(ImmutableMap.of(
+                GeneralOption.BUILD_TOOL.getKey(), GRADLE,
+                GeneralOption.SPOTBUGS_LOAD_PROPERTIES_FROM.getKey(), "src/test/resources/spotbugs/spotbugs-config.properties"
+        ));
         spotBugsProcessor = new SpotBugsProcessor(config);
     }
 
@@ -54,4 +59,10 @@ class SpotBugsProcessorTest extends TestEnvironment {
         assertThat(reviewResult.getViolations()).isEmpty();
     }
 
+    @Test
+    void shouldLoadPropertiesFromExternalLocation() {
+        ReviewResult reviewResult = spotBugsProcessor.process(nonExistentReview());
+
+        assertThat(SystemProperties.getBoolean("findbugs.de.comment")).isTrue();
+    }
 }

--- a/src/test/resources/spotbugs/spotbugs-config.properties
+++ b/src/test/resources/spotbugs/spotbugs-config.properties
@@ -1,0 +1,2 @@
+# Don't report empty catch blocks if a source comment is found in the block.
+findbugs.de.comment = true


### PR DESCRIPTION
Some detector can be configured with these properties, also debugging
can be turned on if needed.

The option name is the same as the one that is used in Spotbugs
itself ('findbugs.loadPropertiesFrom')