### PR TITLE
Set config_loc property for Checkstyle

### DIFF
--- a/src/test/java/pl/touk/sputnik/processor/checkstyle/CheckstyleProcessorTest.java
+++ b/src/test/java/pl/touk/sputnik/processor/checkstyle/CheckstyleProcessorTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import com.google.common.collect.ImmutableMap;
 
 import pl.touk.sputnik.TestEnvironment;
+import pl.touk.sputnik.configuration.Configuration;
 import pl.touk.sputnik.configuration.ConfigurationSetup;
 import pl.touk.sputnik.configuration.GeneralOption;
 import pl.touk.sputnik.review.ReviewResult;
@@ -37,5 +38,21 @@ class CheckstyleProcessorTest extends TestEnvironment {
                         "Missing package-info.java file.",
                         "Missing a Javadoc comment."
                 );
+    }
+
+    @Test
+    void shouldConsiderSuppressionsWithConfigLocProperty() {
+        Configuration configWithSuppressions = new ConfigurationSetup().setUp(ImmutableMap.of(
+                GeneralOption.CHECKSTYLE_CONFIGURATION_FILE.getKey(), "src/test/resources/checkstyle/checkstyle-with-suppressions.xml"));
+        CheckstyleProcessor fixtureWithSuppressions = new CheckstyleProcessor(configWithSuppressions);
+
+        ReviewResult reviewResult = fixtureWithSuppressions.process(review());
+
+        assertThat(reviewResult)
+                .isNotNull()
+                .extracting(ReviewResult::getViolations).asList()
+                .hasSize(2)
+                .extracting("message")
+                .containsOnly("Missing a Javadoc comment.");
     }
 }

--- a/src/test/resources/checkstyle/checkstyle-with-suppressions.xml
+++ b/src/test/resources/checkstyle/checkstyle-with-suppressions.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN" "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="SuppressionFilter">
+        <property name="file" value="${config_loc}/suppressions.xml"/>
+    </module>
+    <module name="NewlineAtEndOfFile">
+        <property name="lineSeparator" value="lf"/>
+    </module>
+    <module name="JavadocPackage"/>
+
+    <module name="TreeWalker">
+        <!-- Javadoc Comments -->
+        <module name="AtclauseOrder"/>
+        <module name="JavadocMethod">
+            <property name="allowUndeclaredRTE" value="true"/>
+            <property name="allowThrowsTagsForSubclasses" value="true"/>
+            <property name="allowMissingPropertyJavadoc" value="true"/>
+        </module>
+        <module name="JavadocParagraph"/>
+        <module name="JavadocStyle">
+            <property name="scope" value="public"/>
+        </module>
+        <module name="JavadocTagContinuationIndentation"/>
+        <module name="JavadocType">
+            <property name="authorFormat" value="\S"/>
+            <!-- avoid errors on tag '@noinspection' -->
+            <property name="allowUnknownTags" value="true"/>
+        </module>
+        <module name="JavadocVariable"/>
+        <module name="NonEmptyAtclauseDescription"/>
+        <module name="SingleLineJavadoc"/>
+        <module name="SummaryJavadoc"/>
+    </module>
+</module>

--- a/src/test/resources/checkstyle/suppressions.xml
+++ b/src/test/resources/checkstyle/suppressions.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suppressions PUBLIC "-//Puppy Crawl//DTD Suppressions 1.1//EN" "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<suppressions>
+    <suppress files="TestFile.java" checks="JavadocPackage"/>
+</suppressions>


### PR DESCRIPTION
This is a half-official property, that is not set by Checkstyle itself
by default, but provided by IDE tools for Eclipse and IDEA.

In order to use the same configuration for IDE and Sputnik, it's useful
to have this property set here also