### PR TITLE
Send comments as robotComments (#238)

### DIFF
--- a/src/main/java/pl/touk/sputnik/connector/gerrit/ReviewInputBuilder.java
+++ b/src/main/java/pl/touk/sputnik/connector/gerrit/ReviewInputBuilder.java
@@ -12,7 +12,7 @@ import pl.touk.sputnik.review.Review;
 import pl.touk.sputnik.review.ReviewFile;
 
 import java.util.HashMap;
-import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @AllArgsConstructor
@@ -29,21 +29,24 @@ public class ReviewInputBuilder {
         if (StringUtils.isNotBlank(tag)) {
             reviewInput.tag = tag;
         }
-        reviewInput.comments = review.getFiles().stream()
+        reviewInput.robotComments = review.getFiles().stream()
                 .collect(Collectors.toMap(ReviewFile::getReviewFilename, this::buildFileComments));
         return reviewInput;
     }
 
     @NotNull
-    private List<ReviewInput.CommentInput> buildFileComments(@NotNull ReviewFile reviewFile) {
+    private List<ReviewInput.RobotCommentInput> buildFileComments(@NotNull ReviewFile reviewFile) {
         return reviewFile.getComments().stream()
                 .map(this::buildCommentInput)
                 .collect(Collectors.toList());
     }
 
     @NotNull
-    private ReviewInput.CommentInput buildCommentInput(Comment comment) {
-        ReviewInput.CommentInput commentInput = new ReviewInput.CommentInput();
+    private ReviewInput.RobotCommentInput buildCommentInput(Comment comment) {
+        ReviewInput.RobotCommentInput commentInput = new ReviewInput.RobotCommentInput();
+
+        commentInput.robotId = "sputnik";
+        commentInput.robotRunId = UUID.randomUUID().toString();
         commentInput.line = comment.getLine();
         commentInput.message = comment.getMessage();
         return commentInput;

--- a/src/test/java/pl/touk/sputnik/connector/gerrit/ReviewInputBuilderTest.java
+++ b/src/test/java/pl/touk/sputnik/connector/gerrit/ReviewInputBuilderTest.java
@@ -1,6 +1,7 @@
 package pl.touk.sputnik.connector.gerrit;
 
 import com.google.gerrit.extensions.api.changes.ReviewInput;
+import com.google.gerrit.extensions.api.changes.ReviewInput.RobotCommentInput;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -10,6 +11,8 @@ import pl.touk.sputnik.ReviewBuilder;
 import pl.touk.sputnik.configuration.Configuration;
 import pl.touk.sputnik.configuration.ConfigurationBuilder;
 import pl.touk.sputnik.review.Review;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -28,10 +31,15 @@ class ReviewInputBuilderTest {
         ReviewInput reviewInput = reviewInputBuilder.toReviewInput(review, TAG);
 
         assertThat(reviewInput.message).isEqualTo("Total 8 violations found");
-        assertThat(reviewInput.comments).hasSize(4);
+        assertThat(reviewInput.comments).isNull();
+        assertThat(reviewInput.robotComments).hasSize(4);
         assertThat(reviewInput.tag).isEqualTo(TAG);
-        assertThat(reviewInput.comments.get("filename1")).hasSize(2);
-        assertThat(reviewInput.comments.get("filename1").get(0).message).isEqualTo("test1");
+        List<RobotCommentInput> file1comments = reviewInput.robotComments.get("filename1");
+        assertThat(file1comments).hasSize(2);
+        RobotCommentInput comment1 = file1comments.get(0);
+        assertThat(comment1.message).isEqualTo("test1");
+        assertThat(comment1.robotId).isEqualTo("sputnik");
+        assertThat(comment1.robotRunId).isNotEmpty();
         assertThat(reviewInput.labels.get("Code-Review")).isEqualTo((short) 1);
     }
 


### PR DESCRIPTION
Robot comments show up in the Findings tab, instead of in the comments.
This makes it much easier to differentiate from them a reviewer's
comments.

The API requires a "runId" for the comment. I've chosen to just send a
random UUID for now, but eventually we could wire in something like a
build number or something.