### PR TITLE
passing comment: add ability to disable

### DIFF
--- a/src/main/java/pl/touk/sputnik/configuration/GeneralOption.java
+++ b/src/main/java/pl/touk/sputnik/configuration/GeneralOption.java
@@ -17,6 +17,7 @@ public enum GeneralOption implements ConfigurationOption {
 
     MESSAGE_COMMENT_FORMAT("message.commentFormat", "Sputnik comment format. {0}: reporter, {1}: level, {2}: message", "[{0}] {1}: {2}"),
     MESSAGE_PROBLEM_FORMAT("message.problemFormat", "Sputnik problem format. {0}: reporter, {1}: message", "There is a problem with {0}: {1}"),
+    MESSAGE_PASSING_COMMENT_ENABLED("message.passingCommentEnabled", "Passing Comment enabled", "true"),
     MESSAGE_SCORE_PASSING_COMMENT("message.scorePassingComment", "Comment when no errors are found", "Perfect!"),
 
     CONNECTOR_TYPE("connector.type", "Connector: <stash|gerrit|github|saas|local>", ConnectorType.GERRIT.getName()),

--- a/src/main/java/pl/touk/sputnik/engine/VisitorBuilder.java
+++ b/src/main/java/pl/touk/sputnik/engine/VisitorBuilder.java
@@ -65,7 +65,9 @@ public class VisitorBuilder {
 
         addCommentVisitor(afterReviewVisitors, configuration, connectorFacade);
 
-        String passingComment = configuration.getProperty(GeneralOption.MESSAGE_SCORE_PASSING_COMMENT);
+        String passingComment= null;
+        if (configuration.getProperty(GeneralOption.MESSAGE_PASSING_COMMENT_ENABLED))
+            passingComment = configuration.getProperty(GeneralOption.MESSAGE_SCORE_PASSING_COMMENT);
         afterReviewVisitors.add(new SummaryMessageVisitor(passingComment));
 
         int maxNumberOfComments = NumberUtils.toInt(configuration.getProperty(GeneralOption.MAX_NUMBER_OF_COMMENTS), 0);

--- a/src/main/java/pl/touk/sputnik/engine/visitor/SummaryMessageVisitor.java
+++ b/src/main/java/pl/touk/sputnik/engine/visitor/SummaryMessageVisitor.java
@@ -22,6 +22,8 @@ public class SummaryMessageVisitor implements AfterReviewVisitor {
 
     private void addSummaryMessage(Review review) {
         String summaryMessage = getSummaryMessage(review);
+        if (summaryMessage == null) return;
+        
         log.info("Adding summary message to review: {}", summaryMessage);
         review.getMessages().add(summaryMessage);
     }

--- a/src/test/java/pl/touk/sputnik/engine/visitor/SummaryMessageVisitorTest.java
+++ b/src/test/java/pl/touk/sputnik/engine/visitor/SummaryMessageVisitorTest.java
@@ -61,6 +61,15 @@ class SummaryMessageVisitorTest {
     }
 
     @Test
+    void shouldNotAddPerfectMessageIfThereAreNoViolationsFound() {
+        when(review.getTotalViolationCount()).thenReturn(0L);
+
+        noPerfectSummaryMessageVisitor.afterReview(review);
+
+        assertThat(review.getMessages()).isEmpty();
+    }
+
+    @Test
     void shouldAddProblemMessagesPerfectMessageIfThereAreNoViolationsFound() {
         when(review.getTotalViolationCount()).thenReturn(8L);
         when(review.getProblems()).thenReturn(singletonList("There is a problem with PMD: configuration error"));


### PR DESCRIPTION
Add an enable/disable option to the configuration so that a dev can
disable the "Perfect!" message.

For testing, I added a test that sets `message.scorePassingComment` 
to null, which should add no messages to the review.