### PR TITLE
Bump spotbugs to 4.8.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,8 +102,9 @@ dependencies {
     }
 
     // SpotBugs dependencies
-    implementation('com.github.spotbugs:spotbugs:4.2.0') {
+    implementation('com.github.spotbugs:spotbugs:4.8.6') {
         exclude group: 'org.slf4j'
+        exclude group: 'ch.qos.logback'
     }
 
     // Scalastyle http://www.scalastyle.org/


### PR DESCRIPTION
- Bump the spotbugs dependency from 4.2.0 to the latest version 4.8.6.
- This is needed for Java 21 support, see spotbugs releasenotes: https://github.com/spotbugs/spotbugs/releases/tag/4.8.0
- Need to exclude logback from spotbugs since it's a newer version compiled with class version 55 (we are still on class version 52 with JDK 1.8).