### PR TITLE
Bump checkstyle to 10.21.1 and CodeNarc to 3.5.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,8 +37,8 @@ configurations {
 
 project.version = findProperty("version") ?: scmVersion.version
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 group = 'pl.touk'
 mainClassName = 'pl.touk.sputnik.Main'
 
@@ -79,7 +79,7 @@ dependencies {
     implementation 'com.urswolfer.gerrit.client.rest:gerrit-rest-java-client:0.9.3'
 
     // Checkstyle dependencies
-    implementation('com.puppycrawl.tools:checkstyle:8.1') {
+    implementation('com.puppycrawl.tools:checkstyle:10.21.1') {
         exclude group: 'com.google.guava'
     }
 
@@ -110,12 +110,11 @@ dependencies {
     implementation 'org.scalastyle:scalastyle_2.10:0.4.0'
 
     // CodeNarc http://codenarc.sourceforge.net/
-    implementation('org.codenarc:CodeNarc:1.4') {
+    implementation('org.codenarc:CodeNarc:3.5.0') {
         exclude module: 'groovy'
         exclude group: 'junit'
     }
-
-    implementation 'org.codehaus.groovy:groovy:2.3.4'
+    implementation 'org.codehaus.groovy:groovy:3.0.9' // 3.0.9 in CodeNarc
 
     // JSLint
     implementation 'com.googlecode.jslint4java:jslint4java:2.0.5'

--- a/src/test/resources/checkstyle/checkstyle-with-suppressions.xml
+++ b/src/test/resources/checkstyle/checkstyle-with-suppressions.xml
@@ -12,9 +12,8 @@
     <module name="TreeWalker">
         <!-- Javadoc Comments -->
         <module name="AtclauseOrder"/>
-        <module name="JavadocMethod">
-            <property name="allowUndeclaredRTE" value="true"/>
-            <property name="allowThrowsTagsForSubclasses" value="true"/>
+        <module name="JavadocMethod"/>
+        <module name="MissingJavadocMethod">
             <property name="allowMissingPropertyJavadoc" value="true"/>
         </module>
         <module name="JavadocParagraph"/>
@@ -27,6 +26,7 @@
             <!-- avoid errors on tag '@noinspection' -->
             <property name="allowUnknownTags" value="true"/>
         </module>
+        <module name="MissingJavadocType"/>
         <module name="JavadocVariable"/>
         <module name="NonEmptyAtclauseDescription"/>
         <module name="SingleLineJavadoc"/>

--- a/src/test/resources/checkstyle/checkstyle.xml
+++ b/src/test/resources/checkstyle/checkstyle.xml
@@ -9,9 +9,8 @@
     <module name="TreeWalker">
         <!-- Javadoc Comments -->
         <module name="AtclauseOrder"/>
-        <module name="JavadocMethod">
-            <property name="allowUndeclaredRTE" value="true"/>
-            <property name="allowThrowsTagsForSubclasses" value="true"/>
+        <module name="JavadocMethod"/>
+        <module name="MissingJavadocMethod">
             <property name="allowMissingPropertyJavadoc" value="true"/>
         </module>
         <module name="JavadocParagraph"/>
@@ -24,6 +23,7 @@
             <!-- avoid errors on tag '@noinspection' -->
             <property name="allowUnknownTags" value="true"/>
         </module>
+        <module name="MissingJavadocType"/>
         <module name="JavadocVariable"/>
         <module name="NonEmptyAtclauseDescription"/>
         <module name="SingleLineJavadoc"/>

--- a/src/test/resources/java/TestFile.java
+++ b/src/test/resources/java/TestFile.java
@@ -1,4 +1,4 @@
-class TestFile {
+public class TestFile {
     public String foo() {
         return "bar";
     }


### PR DESCRIPTION
- Bump the checkstyle dependency from 8.1 to the latest version 10.21.1
- This is needed in particular for Java 21 support, see releasenotes: https://checkstyle.sourceforge.io/releasenotes.html#Release_10.18.0
- We need to bump to JDK 11 since the new version of checkstyle requires it: checkstyle/checkstyle#9146.
- Migrate checkstyle xml to remove deprecated properties and add new modules, see:
  - checkstyle/checkstyle#7096
  - checkstyle/checkstyle#6703
- Made TestFile.java public to trigger the missing javadoc warnings.
- Bump CodeNarc from 1.4 to 3.5.0 due to class loading issues on JDK 11.
- This means we also need to bump groovy to 3.0.9.